### PR TITLE
[FEAT] #16 record 검증 로직 어노테이션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	implementation 'org.aspectj:aspectjweaver:1.9.22.1'
+
 	//Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -70,6 +72,8 @@ test {
 		systemProperty 'spring.profiles.active', 'test'
 	}
 
+	jvmArgs += "-javaagent:${configurations.runtimeClasspath.find { it.name.contains('aspectjweaver') }}"
+
 	useJUnitPlatform()
 }
 
@@ -89,6 +93,10 @@ bootJar {
 	from("${asciidoctor.outputDir}") {
 		into 'static/docs'
 	}
+}
+
+bootRun {
+	jvmArgs += "-javaagent:${configurations.runtimeClasspath.find { it.name.contains('aspectjweaver') }}"
 }
 
 clean {

--- a/src/main/java/com/readysetgo/traveltracker/common/annotation/BuilderValidator.java
+++ b/src/main/java/com/readysetgo/traveltracker/common/annotation/BuilderValidator.java
@@ -1,0 +1,19 @@
+package com.readysetgo.traveltracker.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 롬복 {@link lombok.Builder} 어노테이션과 함께 사용하여 빌더 패턴으로 생성된 객체의 유효성 검사를 수행하는 어노테이션입니다.
+ * <p>
+ * 이 어노테이션이 클래스나 레코드에 적용되면, {@link com.readysetgo.traveltracker.common.util.ValidationUtils}를 통해 빌더
+ * 메서드 실행 시 유효성 검사가 자동으로 수행됩니다.
+ * </p>
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BuilderValidator {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/common/annotation/ValidationAspect.java
+++ b/src/main/java/com/readysetgo/traveltracker/common/annotation/ValidationAspect.java
@@ -1,0 +1,74 @@
+package com.readysetgo.traveltracker.common.annotation;
+
+import com.readysetgo.traveltracker.common.util.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+/**
+ * Lombok의 빌더 메서드가 호출될 때, {@link BuilderValidator} 어노테이션이 적용된 클래스의 객체에 대해 유효성 검사를 수행하는 AOP 클래스입니다.
+ */
+@Aspect
+@Component
+@Slf4j
+public class ValidationAspect {
+
+    /**
+     * 빌더 메서드를 대상으로 하는 포인트컷 정의
+     * <p>build() 메서드를 실행 대상으로 설정합니다.</p>
+     */
+    @Pointcut("execution(* com.readysetgo.traveltracker..*.build(..))")
+    public void builderMethodExecution() {
+    }
+
+    /**
+     * 빌더 메서드 실행 시 유효성 검사를 수행하는 어드바이스
+     * <p>빌더 메서드를 호출할 때, 해당 메서드가 소속된 외부 클래스에 {@link BuilderValidator} 어노테이션이 존재하는지 확인하고,
+     * 유효성 검사를 수행합니다.</p>
+     *
+     * @param joinPoint 빌더 메서드의 실행 지점
+     * @return 유효성 검사 후 생성된 객체
+     * @throws Throwable 유효성 검사 실패 시 발생하는 예외
+     */
+    @Around("builderMethodExecution()")
+    public Object validateBuilderMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+        // 빌더의 외부 클래스가 @BuilderValidator 어노테이션을 가지고 있는지 확인
+        if (isParentClassAnnotatedWithBuilderValidator(joinPoint)) {
+            // INFO: 유효성 검사를 시작하며, 대상 클래스만 출력
+            Class<?> parentClass = joinPoint.getTarget().getClass().getEnclosingClass();
+            log.info("유효성 검사를 시작합니다 - 대상 클래스: {}",
+                parentClass != null ? parentClass.getName() : "알 수 없는 클래스");
+
+            // build() 메서드를 호출하여 객체 생성
+            Object builtObject = joinPoint.proceed();
+
+            // 유효성 검사 수행
+            ValidationUtils.validate(builtObject);
+
+            // INFO: 유효성 검사 완료 로그 출력
+            log.info("유효성 검사 완료 - 대상 객체: {}", builtObject);
+            return builtObject;
+        }
+
+        // DEBUG: 어노테이션이 없는 경우 로그 출력
+        log.debug("유효성 검사가 필요하지 않은 클래스에서 build()가 호출되었습니다 - 메서드: {}", joinPoint.getSignature());
+        return joinPoint.proceed();
+    }
+
+    /**
+     * 빌더의 외부 클래스가 {@link BuilderValidator} 어노테이션을 가지고 있는지 확인합니다.
+     *
+     * @param joinPoint 빌더 메서드의 실행 지점
+     * @return 외부 클래스가 @BuilderValidator 어노테이션을 가지고 있으면 true, 그렇지 않으면 false
+     */
+    private boolean isParentClassAnnotatedWithBuilderValidator(ProceedingJoinPoint joinPoint) {
+        Class<?> builderClass = joinPoint.getTarget().getClass();
+        Class<?> parentClass = builderClass.getEnclosingClass();
+
+        // 외부 클래스가 @BuilderValidator 어노테이션을 가지고 있는지 확인
+        return parentClass != null && parentClass.isAnnotationPresent(BuilderValidator.class);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/common/config/AspectConfig.java
+++ b/src/main/java/com/readysetgo/traveltracker/common/config/AspectConfig.java
@@ -1,0 +1,21 @@
+package com.readysetgo.traveltracker.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+/**
+ * 애플리케이션의 AOP 설정을 활성화하는 설정 클래스입니다.
+ * <p>
+ * 이 클래스는 AspectJ 스타일의 AOP 기능을 사용하기 위해 {@link EnableAspectJAutoProxy} 어노테이션을 활성화하여 프록시 기반의 AOP를
+ * 설정합니다.
+ * </p>
+ * <p>
+ * `proxyTargetClass` 속성을 `true`로 설정하여 CGLIB 프록시를 강제로 사용하게 하며, 인터페이스가 없는 클래스에도 AOP 기능을 적용할 수 있도록
+ * 지원합니다.
+ * </p>
+ */
+@Configuration
+@EnableAspectJAutoProxy(proxyTargetClass = true) // AspectJ 스타일 AOP 설정을 활성화
+public class AspectConfig {
+
+}

--- a/src/main/resources/META-INF/aop.xml
+++ b/src/main/resources/META-INF/aop.xml
@@ -1,0 +1,9 @@
+<aspectj>
+  <aspects>
+    <aspect name="com.readysetgo.traveltracker.common.annotation.ValidationAspect"/>
+  </aspects>
+  <weaver options="-Xlint:ignore">
+    <!-- 적용할 패키지 설정 -->
+    <include within="com.readysetgo.traveltracker..*"/>
+  </weaver>
+</aspectj>


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #16

## 📌 PR 요약

AOP 설정을 추가하고, 빌더 객체의 유효성 검사 기능을 구현했습니다. 
이를 통해 빌더 패턴으로 생성된 객체에 대한 유효성 검사를 자동으로 수행할 수 있습니다.

## 🔍 주요 변경 사항

- **AOP 설정 추가 및 AspectJ 의존성 적용**
  - 유효성 검사를 위한 `aspectjweaver` 의존성 추가
  - AOP 활성화를 위해 `@EnableAspectJAutoProxy`와 `aop.xml` 파일 설정
- **`AspectConfig` 클래스 추가**
  - AOP 설정 활성화 및 프록시 적용을 위한 설정 포함
- **유효성 검사 기능 구현**
  - `BuilderValidator` 어노테이션 정의: 빌더 객체 유효성 검사 용도
  - `ValidationAspect` 클래스 추가: 빌더 메서드 실행 시 유효성 검사 수행
    - 빌더 메서드 호출 시 클래스 및 메서드 로깅

## 🧪 테스트 방법
```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [ ] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- `@Builder` 로 생성된 메소드 중 `@BuilderValidator` 가 추가된 클래스 및 record 를 대상으로 검증 합니다
- AOP 설정이 정상적으로 적용되었는지 확인