### PR TITLE
[FEAT] #12 #13 마커 기본 기능 구현

### DIFF
--- a/src/docs/asciidoc/api/marker/create-marker.adoc
+++ b/src/docs/asciidoc/api/marker/create-marker.adoc
@@ -1,0 +1,11 @@
+[[create-marker]]
+=== 마커 생성
+
+==== HTTP Request
+
+include::{snippets}/create-marker/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/create-marker/http-response.adoc[]
+include::{snippets}/create-marker/response-fields.adoc[]

--- a/src/docs/asciidoc/api/marker/delete-marker.adoc
+++ b/src/docs/asciidoc/api/marker/delete-marker.adoc
@@ -1,0 +1,11 @@
+[[delete-marker]]
+=== 마커 삭제
+
+==== HTTP Request
+
+include::{snippets}/delete-marker/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/delete-marker/http-response.adoc[]
+include::{snippets}/delete-marker/response-fields.adoc[]

--- a/src/docs/asciidoc/api/marker/get-marker-info.adoc
+++ b/src/docs/asciidoc/api/marker/get-marker-info.adoc
@@ -1,0 +1,11 @@
+[[get-marker-info]]
+=== 마커 정보 조회
+
+==== HTTP Request
+
+include::{snippets}/get-marker/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/get-marker/http-response.adoc[]
+include::{snippets}/get-marker/response-fields.adoc[]

--- a/src/docs/asciidoc/api/marker/update-marker.adoc
+++ b/src/docs/asciidoc/api/marker/update-marker.adoc
@@ -1,0 +1,12 @@
+[[update-marker]]
+=== 마커 수정
+
+==== HTTP Request
+
+include::{snippets}/update-marker/http-request.adoc[]
+include::{snippets}/update-marker/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/update-marker/http-response.adoc[]
+include::{snippets}/update-marker/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,3 +16,11 @@ include::api/group/create-group.adoc[]
 include::api/group/get-group-info.adoc[]
 include::api/group/update-group.adoc[]
 include::api/group/delete-group.adoc[]
+
+[[marker-API]]
+== Marker API
+
+include::api/marker/create-marker.adoc[]
+include::api/marker/get-marker-info.adoc[]
+include::api/marker/update-marker.adoc[]
+include::api/marker/delete-marker.adoc[]

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/CreateMarkerController.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/CreateMarkerController.java
@@ -1,0 +1,31 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.marker.adapter.in.web.request.CreateMarkerRequest;
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.CreateMarkerResponse;
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class CreateMarkerController {
+
+    private final CreateMarkerUseCase createMarkerUseCase;
+
+    @PostMapping("/v1/markers")
+    public CreateMarkerResponse createMarker(@RequestBody CreateMarkerRequest request) {
+
+        return createMarkerUseCase.createMarker(CreateMarkerCommand.builder()
+            .diaryContent(request.diaryContent())
+            .diaryTitle(request.diaryTitle())
+            .locationName(request.locationName())
+            .latitude(request.latitude())
+            .longitude(request.longitude())
+            .build());
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/DeleteMarkerController.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/DeleteMarkerController.java
@@ -1,0 +1,21 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.marker.application.port.in.DeleteMarkerUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class DeleteMarkerController {
+
+    private final DeleteMarkerUseCase deleteMarkerUseCase;
+
+    @DeleteMapping("/v1/markers/{markerId}")
+    public Boolean deleteMarker(@PathVariable Long markerId) {
+        return deleteMarkerUseCase.deleteMarker(markerId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/GetMarkerInfoController.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/GetMarkerInfoController.java
@@ -1,0 +1,22 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.GetMarkerInfoResponse;
+import com.readysetgo.traveltracker.marker.application.port.in.GetMarkerInfoQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class GetMarkerInfoController {
+
+    private final GetMarkerInfoQuery getMarkerInfoQuery;
+
+    @GetMapping("/v1/markers/{markerId}")
+    public GetMarkerInfoResponse getMarkerInfo(@PathVariable Long markerId) {
+        return getMarkerInfoQuery.getMarkerInfo(markerId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/UpdateMarkerController.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/UpdateMarkerController.java
@@ -1,0 +1,32 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.marker.adapter.in.web.request.UpdateMarkerRequest;
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class UpdateMarkerController {
+
+    private final UpdateMarkerUseCase updateMarkerUseCase;
+
+    @PutMapping("/v1/markers/{markerId}")
+    public Boolean updateMarker(
+        @PathVariable Long markerId,
+        @RequestBody UpdateMarkerRequest request
+    ) {
+        return updateMarkerUseCase.updateMarker(UpdateMarkerCommand.builder()
+            .markerId(markerId)
+            .locationName(request.locationName())
+            .diaryTitle(request.diaryTitle())
+            .diaryContent(request.diaryContent())
+            .build());
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/request/CreateMarkerRequest.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/request/CreateMarkerRequest.java
@@ -1,0 +1,14 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web.request;
+
+import lombok.Builder;
+
+@Builder
+public record CreateMarkerRequest(
+    String locationName,
+    String diaryTitle,
+    String diaryContent,
+    Double latitude,
+    Double longitude
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/request/UpdateMarkerRequest.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/request/UpdateMarkerRequest.java
@@ -1,0 +1,12 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web.request;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateMarkerRequest(
+    String locationName,
+    String diaryTitle,
+    String diaryContent
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/response/CreateMarkerResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/response/CreateMarkerResponse.java
@@ -1,0 +1,5 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web.response;
+
+public record CreateMarkerResponse(Long markerId) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/response/GetMarkerInfoResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/in/web/response/GetMarkerInfoResponse.java
@@ -1,0 +1,16 @@
+package com.readysetgo.traveltracker.marker.adapter.in.web.response;
+
+import lombok.Builder;
+
+@Builder
+public record GetMarkerInfoResponse(
+    Long markerId,
+    String locationName,
+    String diaryTitle,
+    String diaryContent,
+    Double latitude,
+    Double longitude
+) {
+
+}
+

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/CreateMarkerAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/CreateMarkerAdapter.java
@@ -1,0 +1,33 @@
+package com.readysetgo.traveltracker.marker.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.marker.adapter.out.persistence.MarkerJpaEntity;
+import com.readysetgo.traveltracker.marker.adapter.out.persistence.MarkerRepository;
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.out.CreateMarkerPort;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class CreateMarkerAdapter implements CreateMarkerPort {
+
+    private final MarkerRepository markerRepository;
+
+    @Override
+    public Long createMarker(CreateMarkerCommand command) {
+        MarkerJpaEntity marker = createMarkerEntity(command);
+        markerRepository.save(marker);
+
+        return marker.getId();
+    }
+
+    private MarkerJpaEntity createMarkerEntity(CreateMarkerCommand command) {
+        return MarkerJpaEntity.builder()
+            .locationName(command.locationName())
+            .diaryTitle(command.diaryTitle())
+            .diaryContent(command.diaryContent())
+            .latitude(command.latitude())
+            .longitude(command.longitude())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/DeleteMarkerAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/DeleteMarkerAdapter.java
@@ -1,0 +1,20 @@
+package com.readysetgo.traveltracker.marker.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.marker.adapter.out.persistence.MarkerRepository;
+import com.readysetgo.traveltracker.marker.application.port.out.DeleteMarkerPort;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class DeleteMarkerAdapter implements DeleteMarkerPort {
+
+    private final MarkerRepository markerRepository;
+
+    @Override
+    public Boolean deleteMarker(Long markerId) {
+        markerRepository.deleteById(markerId);
+
+        return true;
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/LoadMarkerAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/LoadMarkerAdapter.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.marker.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.marker.adapter.out.persistence.MarkerJpaEntity;
+import com.readysetgo.traveltracker.marker.adapter.out.persistence.MarkerRepository;
+import com.readysetgo.traveltracker.marker.application.port.out.LoadMarkerPort;
+import com.readysetgo.traveltracker.marker.domain.Marker;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LoadMarkerAdapter implements LoadMarkerPort {
+
+    private final MarkerRepository markerRepository;
+
+    @Override
+    public Marker loadMarker(Long markerId) {
+        MarkerJpaEntity marker = markerRepository.findById(markerId)
+            .orElseThrow(RuntimeException::new);
+
+        return Marker.of(
+            marker.getId(),
+            marker.getLocationName(),
+            marker.getDiaryTitle(),
+            marker.getDiaryContent(),
+            marker.getLatitude(),
+            marker.getLongitude()
+        );
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/UpdateMarkerAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/UpdateMarkerAdapter.java
@@ -1,0 +1,29 @@
+package com.readysetgo.traveltracker.marker.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.marker.adapter.out.persistence.MarkerJpaEntity;
+import com.readysetgo.traveltracker.marker.adapter.out.persistence.MarkerRepository;
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.out.UpdateMarkerPort;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class UpdateMarkerAdapter implements UpdateMarkerPort {
+
+    private final MarkerRepository markerRepository;
+
+    @Override
+    public boolean updateMarker(UpdateMarkerCommand command) {
+        MarkerJpaEntity marker = markerRepository.findById(command.markerId())
+            .orElseThrow(RuntimeException::new);
+
+        marker.updateInfo(
+            command.locationName(),
+            command.diaryTitle(),
+            command.diaryContent()
+        );
+
+        return true;
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/persistence/MarkerJpaEntity.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/persistence/MarkerJpaEntity.java
@@ -1,0 +1,49 @@
+package com.readysetgo.traveltracker.marker.adapter.out.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "MARKER")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MarkerJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String locationName;
+
+    private String diaryTitle;
+
+    private String diaryContent;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    @Builder
+    public MarkerJpaEntity(String locationName, String diaryTitle, String diaryContent,
+        Double latitude,
+        Double longitude) {
+        this.locationName = locationName;
+        this.diaryTitle = diaryTitle;
+        this.diaryContent = diaryContent;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public void updateInfo(String diaryContent, String diaryTitle, String locationName) {
+        this.diaryContent = diaryContent;
+        this.diaryTitle = diaryTitle;
+        this.locationName = locationName;
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/persistence/MarkerRepository.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/adapter/out/persistence/MarkerRepository.java
@@ -1,0 +1,7 @@
+package com.readysetgo.traveltracker.marker.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarkerRepository extends JpaRepository<MarkerJpaEntity, Long> {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/CreateMarkerCommand.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/CreateMarkerCommand.java
@@ -1,0 +1,16 @@
+package com.readysetgo.traveltracker.marker.application.port.in;
+
+import com.readysetgo.traveltracker.common.annotation.BuilderValidator;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+@BuilderValidator
+public record CreateMarkerCommand(
+    @NotNull String locationName,
+    @NotNull String diaryTitle,
+    @NotNull String diaryContent,
+    @NotNull Double latitude,
+    @NotNull Double longitude
+) {
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/CreateMarkerUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/CreateMarkerUseCase.java
@@ -1,0 +1,8 @@
+package com.readysetgo.traveltracker.marker.application.port.in;
+
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.CreateMarkerResponse;
+
+public interface CreateMarkerUseCase {
+
+    CreateMarkerResponse createMarker(CreateMarkerCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/DeleteMarkerUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/DeleteMarkerUseCase.java
@@ -1,0 +1,7 @@
+package com.readysetgo.traveltracker.marker.application.port.in;
+
+public interface DeleteMarkerUseCase {
+
+    boolean deleteMarker(Long markerId);
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/GetMarkerInfoQuery.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/GetMarkerInfoQuery.java
@@ -1,0 +1,8 @@
+package com.readysetgo.traveltracker.marker.application.port.in;
+
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.GetMarkerInfoResponse;
+
+public interface GetMarkerInfoQuery {
+
+    GetMarkerInfoResponse getMarkerInfo(Long markerId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/UpdateMarkerCommand.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/UpdateMarkerCommand.java
@@ -1,0 +1,16 @@
+package com.readysetgo.traveltracker.marker.application.port.in;
+
+import com.readysetgo.traveltracker.common.annotation.BuilderValidator;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+@BuilderValidator
+public record UpdateMarkerCommand(
+    @NotNull Long markerId,
+    @NotNull String locationName,
+    @NotNull String diaryTitle,
+    @NotNull String diaryContent
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/UpdateMarkerUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/in/UpdateMarkerUseCase.java
@@ -1,0 +1,7 @@
+package com.readysetgo.traveltracker.marker.application.port.in;
+
+public interface UpdateMarkerUseCase {
+
+    boolean updateMarker(UpdateMarkerCommand command);
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/CreateMarkerPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/CreateMarkerPort.java
@@ -1,0 +1,8 @@
+package com.readysetgo.traveltracker.marker.application.port.out;
+
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerCommand;
+
+public interface CreateMarkerPort {
+
+    Long createMarker(CreateMarkerCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/DeleteMarkerPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/DeleteMarkerPort.java
@@ -1,0 +1,7 @@
+package com.readysetgo.traveltracker.marker.application.port.out;
+
+public interface DeleteMarkerPort {
+
+    Boolean deleteMarker(Long markerId);
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/LoadMarkerPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/LoadMarkerPort.java
@@ -1,0 +1,8 @@
+package com.readysetgo.traveltracker.marker.application.port.out;
+
+import com.readysetgo.traveltracker.marker.domain.Marker;
+
+public interface LoadMarkerPort {
+
+    Marker loadMarker(Long markerId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/UpdateMarkerPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/port/out/UpdateMarkerPort.java
@@ -1,0 +1,8 @@
+package com.readysetgo.traveltracker.marker.application.port.out;
+
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerCommand;
+
+public interface UpdateMarkerPort {
+
+    boolean updateMarker(UpdateMarkerCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/service/CreateMarkerService.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/service/CreateMarkerService.java
@@ -1,0 +1,22 @@
+package com.readysetgo.traveltracker.marker.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.CreateMarkerResponse;
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerUseCase;
+import com.readysetgo.traveltracker.marker.application.port.out.CreateMarkerPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateMarkerService implements CreateMarkerUseCase {
+
+    private final CreateMarkerPort createMarkerPort;
+
+    @Override
+    public CreateMarkerResponse createMarker(CreateMarkerCommand command) {
+        return new CreateMarkerResponse(createMarkerPort.createMarker(command));
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/service/DeleteMarkerService.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/service/DeleteMarkerService.java
@@ -1,0 +1,20 @@
+package com.readysetgo.traveltracker.marker.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.marker.application.port.in.DeleteMarkerUseCase;
+import com.readysetgo.traveltracker.marker.application.port.out.DeleteMarkerPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class DeleteMarkerService implements DeleteMarkerUseCase {
+
+    private final DeleteMarkerPort deleteMarkerPort;
+
+    @Override
+    public boolean deleteMarker(Long markerId) {
+        return deleteMarkerPort.deleteMarker(markerId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/service/GetMarkerInfoService.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/service/GetMarkerInfoService.java
@@ -1,0 +1,31 @@
+package com.readysetgo.traveltracker.marker.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.GetMarkerInfoResponse;
+import com.readysetgo.traveltracker.marker.application.port.in.GetMarkerInfoQuery;
+import com.readysetgo.traveltracker.marker.application.port.out.LoadMarkerPort;
+import com.readysetgo.traveltracker.marker.domain.Marker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetMarkerInfoService implements GetMarkerInfoQuery {
+
+    private final LoadMarkerPort loadMarkerPort;
+
+    @Override
+    public GetMarkerInfoResponse getMarkerInfo(Long markerId) {
+        Marker marker = loadMarkerPort.loadMarker(markerId);
+
+        return new GetMarkerInfoResponse(
+            marker.getId(),
+            marker.getLocationName(),
+            marker.getDiaryTitle(),
+            marker.getDiaryContent(),
+            marker.getLatitude(),
+            marker.getLongitude()
+        );
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/application/service/UpdateMarkerService.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/application/service/UpdateMarkerService.java
@@ -1,0 +1,21 @@
+package com.readysetgo.traveltracker.marker.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerUseCase;
+import com.readysetgo.traveltracker.marker.application.port.out.UpdateMarkerPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class UpdateMarkerService implements UpdateMarkerUseCase {
+
+    private final UpdateMarkerPort updateMarkerPort;
+
+    @Override
+    public boolean updateMarker(UpdateMarkerCommand command) {
+        return updateMarkerPort.updateMarker(command);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/marker/domain/Marker.java
+++ b/src/main/java/com/readysetgo/traveltracker/marker/domain/Marker.java
@@ -1,0 +1,28 @@
+package com.readysetgo.traveltracker.marker.domain;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class Marker {
+
+    private Long id;
+    private final String locationName;
+    private final String diaryTitle;
+    private final String diaryContent;
+    private final Double latitude;
+    private final Double longitude;
+
+    public static Marker ofNew(String locationName, String diaryTitle, String diaryContent,
+        Double latitude, Double longitude) {
+        return of(null, locationName, diaryTitle, diaryContent, latitude, longitude);
+    }
+
+    public static Marker of(Long id, String locationName, String diaryTitle, String diaryContent,
+        Double latitude, Double longitude) {
+        return new Marker(id, locationName, diaryTitle, diaryContent, latitude, longitude);
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
@@ -1,0 +1,72 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.DIARY_CONTENT;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.DIARY_TITLE;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.LATITUDE;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.LOCATION_NAME;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.LONGITUDE;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.UPDATED_DIARY_CONTENT;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.UPDATED_DIARY_TITLE;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.UPDATED_LOCATION_NAME;
+
+import com.readysetgo.traveltracker.common.helper.util.ArbitraryField;
+import com.readysetgo.traveltracker.marker.adapter.in.web.request.CreateMarkerRequest;
+import com.readysetgo.traveltracker.marker.adapter.in.web.request.UpdateMarkerRequest;
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.CreateMarkerResponse;
+import com.readysetgo.traveltracker.marker.adapter.in.web.response.GetMarkerInfoResponse;
+
+/**
+ * API 테스트에서 사용되는 요청 및 응답 객체를 생성하는 헬퍼 클래스입니다.
+ * <p>
+ * 테스트 시 반복적으로 생성되는 객체를 미리 정의하여, 테스트의 간결성과 가독성을 높입니다.
+ * </p>
+ */
+public class ArbitraryFactory {
+
+    /**
+     * 마커 관련 요청 및 응답 객체 생성을 위한 내부 클래스입니다.
+     */
+    public static class Marker {
+
+        /**
+         * 마커 생성 요청 객체
+         */
+        public static final CreateMarkerRequest aCreateMarkerRequest =
+            CreateMarkerRequest.builder()
+                .diaryTitle(DIARY_TITLE)
+                .diaryContent(DIARY_CONTENT)
+                .locationName(LOCATION_NAME)
+                .latitude(LATITUDE)
+                .longitude(LONGITUDE)
+                .build();
+
+        /**
+         * 마커 생성 응답 객체
+         */
+        public static final CreateMarkerResponse aCreateMarkerResponse =
+            new CreateMarkerResponse(ArbitraryField.Marker.ID);
+
+        /**
+         * 마커 수정 요청 객체
+         */
+        public static final UpdateMarkerRequest aUpdateMarkerRequest =
+            UpdateMarkerRequest.builder()
+                .diaryTitle(UPDATED_DIARY_TITLE)
+                .diaryContent(UPDATED_DIARY_CONTENT)
+                .locationName(UPDATED_LOCATION_NAME)
+                .build();
+
+        /**
+         * 마커 정보 조회 응답 객체
+         */
+        public static final GetMarkerInfoResponse aGetMarkerInfoResponse =
+            GetMarkerInfoResponse.builder()
+                .markerId(ArbitraryField.Marker.ID)
+                .diaryTitle(DIARY_TITLE)
+                .diaryContent(DIARY_CONTENT)
+                .locationName(LOCATION_NAME)
+                .latitude(LATITUDE)
+                .longitude(LONGITUDE)
+                .build();
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
@@ -1,0 +1,127 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NULL;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.ResultHandler;
+
+/**
+ * API 문서화를 위한 헬퍼 클래스입니다.
+ * <p>
+ * Marker와 Category 관련 API의 요청 및 응답 필드를 문서화하여 Spring REST Docs를 통해 API 문서를 생성할 수 있도록 지원합니다.
+ * </p>
+ */
+public class DocsHelper {
+
+    /**
+     * 마커 관련 API 문서화를 위한 내부 클래스입니다.
+     */
+    public static class MarkerDocs {
+
+        /**
+         * 마커 생성 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 마커 생성 요청과 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 마커 생성 API의 요청/응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler createMarkerDocumentation() {
+            return MockMvcRestDocumentation.document(Marker.DOC_SECTION_CREATE_MARKER,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("diaryTitle").type(STRING).description("마커 제목"),
+                    fieldWithPath("diaryContent").type(STRING).description("마커 내용"),
+                    fieldWithPath("locationName").type(STRING).description("위치 이름"),
+                    fieldWithPath("latitude").type(NUMBER).description("위도"),
+                    fieldWithPath("longitude").type(NUMBER).description("경도")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data.markerId").type(NUMBER).description("생성된 마커 ID"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 마커 조회 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 마커 조회 요청에 대한 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 마커 조회 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler getMarkerDocumentation() {
+            return MockMvcRestDocumentation.document(Marker.DOC_SECTION_GET_MARKER,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data.markerId").type(NUMBER).description("마커 ID"),
+                    fieldWithPath("data.diaryTitle").type(STRING).description("마커 제목"),
+                    fieldWithPath("data.diaryContent").type(STRING).description("마커 내용"),
+                    fieldWithPath("data.locationName").type(STRING).description("위치 이름"),
+                    fieldWithPath("data.latitude").type(NUMBER).description("위도"),
+                    fieldWithPath("data.longitude").type(NUMBER).description("경도"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 마커 수정 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 마커 수정 요청과 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 마커 수정 API의 요청/응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler updateMarkerDocumentation() {
+            return MockMvcRestDocumentation.document(Marker.DOC_SECTION_UPDATE_MARKER,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("diaryTitle").type(STRING).description("수정할 마커 제목"),
+                    fieldWithPath("diaryContent").type(STRING).description("수정할 마커 내용"),
+                    fieldWithPath("locationName").type(STRING).description("수정할 위치 이름")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data").type(BOOLEAN).description("수정 성공 여부"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 마커 삭제 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 마커 삭제 요청에 대한 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 마커 삭제 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler deleteMarkerDocumentation() {
+            return MockMvcRestDocumentation.document(Marker.DOC_SECTION_DELETE_MARKER,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data").type(BOOLEAN).description("삭제 성공 여부"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+    }
+
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
@@ -1,0 +1,80 @@
+package com.readysetgo.traveltracker.common.helper.util;
+
+/**
+ * API 테스트에서 사용되는 임의의 필드 값을 정의한 클래스입니다.
+ * <p>
+ * 마커(Marker)와 카테고리(Category) 관련 요청 및 응답 필드 값, URL, 문서화 섹션명을 포함하고 있어 테스트 및 문서화 설정 시 활용됩니다.
+ * </p>
+ */
+public class ArbitraryField {
+
+    /**
+     * 마커 관련 임의의 필드 값과 URL을 정의한 내부 클래스입니다.
+     */
+    public static class Marker {
+
+        /**
+         * 마커 생성 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_CREATE_MARKER = "create-marker";
+        /**
+         * 마커 조회 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_GET_MARKER = "get-marker";
+        /**
+         * 마커 수정 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_UPDATE_MARKER = "update-marker";
+        /**
+         * 마커 삭제 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_DELETE_MARKER = "delete-marker";
+
+        /**
+         * 마커 API의 기본 URL
+         */
+        public static final String MARKER_BASE_URL = "/v1/markers";
+        /**
+         * 마커 ID를 포함한 상세 조회 URL
+         */
+        public static final String MARKER_ID_URL = MARKER_BASE_URL + "/{id}";
+
+        /**
+         * 임의의 마커 ID
+         */
+        public static final Long ID = 12L;
+        /**
+         * 임의의 다이어리 제목
+         */
+        public static final String DIARY_TITLE = "Sample Diary Title";
+        /**
+         * 임의의 다이어리 내용
+         */
+        public static final String DIARY_CONTENT = "Sample Diary Content";
+        /**
+         * 임의의 위치 이름
+         */
+        public static final String LOCATION_NAME = "Seoul Tower";
+        /**
+         * 임의의 위도 값
+         */
+        public static final Double LATITUDE = 37.55;
+        /**
+         * 임의의 경도 값
+         */
+        public static final Double LONGITUDE = 126.98;
+
+        /**
+         * 업데이트된 다이어리 제목
+         */
+        public static final String UPDATED_DIARY_TITLE = "Updated Diary Title";
+        /**
+         * 업데이트된 다이어리 내용
+         */
+        public static final String UPDATED_DIARY_CONTENT = "This content has been updated for testing.";
+        /**
+         * 업데이트된 위치 이름
+         */
+        public static final String UPDATED_LOCATION_NAME = "Namsan Seoul Tower";
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/docs/MarkerControllerDocsTest.java
+++ b/src/test/java/com/readysetgo/traveltracker/docs/MarkerControllerDocsTest.java
@@ -1,0 +1,163 @@
+package com.readysetgo.traveltracker.docs;
+
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Marker.aCreateMarkerRequest;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Marker.aCreateMarkerResponse;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Marker.aGetMarkerInfoResponse;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Marker.aUpdateMarkerRequest;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.MarkerDocs.createMarkerDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.MarkerDocs.deleteMarkerDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.MarkerDocs.getMarkerDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.MarkerDocs.updateMarkerDocumentation;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.ID;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.MARKER_BASE_URL;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Marker.MARKER_ID_URL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.in.CreateMarkerUseCase;
+import com.readysetgo.traveltracker.marker.application.port.in.DeleteMarkerUseCase;
+import com.readysetgo.traveltracker.marker.application.port.in.GetMarkerInfoQuery;
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerCommand;
+import com.readysetgo.traveltracker.marker.application.port.in.UpdateMarkerUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/**
+ * 마커 API에 대한 REST Docs 테스트 클래스입니다.
+ * <p>
+ * 마커 생성, 조회, 수정, 삭제 요청의 API 문서화를 위해 MockMVC와 REST Docs를 이용해 요청 및 응답 필드를 문서화하고 예제 테스트 케이스를 제공합니다.
+ * </p>
+ */
+@DisplayName("마커 API 문서 생성 테스트")
+public class MarkerControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private CreateMarkerUseCase createMarkerUseCase;
+
+    @MockBean
+    private GetMarkerInfoQuery getMarkerInfoQuery;
+
+    @MockBean
+    private UpdateMarkerUseCase updateMarkerUseCase;
+
+    @MockBean
+    private DeleteMarkerUseCase deleteMarkerUseCase;
+
+    /**
+     * 마커 생성 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("마커 생성 요청")
+    class CreateMarker {
+
+        /**
+         * 유효한 마커 생성 요청 시 성공적으로 마커가 생성되고, API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("마커 생성 성공")
+        void validMarkerRequest_createsMarker_returnsCreatedStatus() throws Exception {
+            given(createMarkerUseCase.createMarker(any(CreateMarkerCommand.class)))
+                .willReturn(aCreateMarkerResponse);
+
+            String body = objectMapper.writeValueAsString(aCreateMarkerRequest);
+
+            mockMvc.perform(post(MARKER_BASE_URL)
+                    .contentType(APPLICATION_JSON)
+                    .content(body))
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 201로 수정 필요
+                .andDo(createMarkerDocumentation());
+        }
+    }
+
+    /**
+     * 마커 조회 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("마커 조회 요청")
+    class GetMarkerInfo {
+
+        /**
+         * 존재하는 마커 ID로 요청 시, 마커 정보를 성공적으로 조회하고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("마커 조회 성공")
+        void existingMarkerId_retrievesMarker_returnsMarkerDetails() throws Exception {
+            given(getMarkerInfoQuery.getMarkerInfo(anyLong()))
+                .willReturn(aGetMarkerInfoResponse);
+
+            mockMvc.perform(get(MARKER_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(getMarkerDocumentation());
+        }
+    }
+
+    /**
+     * 마커 수정 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("마커 수정 요청")
+    class UpdateMarker {
+
+        /**
+         * 유효한 마커 수정 요청 시 성공적으로 마커가 수정되고, API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("마커 수정 성공")
+        void validUpdateRequest_updatesMarker_returnsOkStatus() throws Exception {
+            given(updateMarkerUseCase.updateMarker(any(UpdateMarkerCommand.class)))
+                .willReturn(true);
+
+            String body = objectMapper.writeValueAsString(aUpdateMarkerRequest);
+
+            mockMvc.perform(put(MARKER_ID_URL, ID)
+                    .contentType(APPLICATION_JSON)
+                    .content(body))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(updateMarkerDocumentation());
+        }
+    }
+
+    /**
+     * 마커 삭제 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("마커 삭제 요청")
+    class DeleteMarker {
+
+        /**
+         * 존재하는 마커 ID로 삭제 요청 시, 성공적으로 마커가 삭제되고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("마커 삭제 성공")
+        void existingMarkerId_deletesMarker_returnsNoContentStatus() throws Exception {
+            given(deleteMarkerUseCase.deleteMarker(anyLong())).willReturn(true);
+
+            mockMvc.perform(delete(MARKER_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 204로 수정 필요
+                .andDo(deleteMarkerDocumentation());
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #12, 
Closes #13

## 📌 PR 요약

마커 엔티티와 관련된 CRUD 기능을 구현하고, 이를 기반으로 한 도메인 모델, 레포지토리, 서비스, 컨트롤러를 추가하였습니다.

## 🔍 주요 변경 사항

- `MakerJpaEntity` 생성
  - 필드 정의: `locationName`, `diaryTitle`, `diaryContent`, `latitude`, `longitude`
  - JPA 관련 어노테이션 적용: `@Entity`, `@Table`
  - 빌더 패턴 추가
- `MakerRepository` 생성
  - `JpaRepository` 상속 및 엔티티와 연동된 CRUD 처리
- 마커 생성 기능 구현
  - `CreateMakerCommand`, `CreateMakerAdapter`, `CreateMakerService` 및 `CreateMakerController` 추가
  - POST `/v1/makers` 엔드포인트 구현
- `Maker` 도메인 모델 생성
  - 정적 팩토리 메서드(`of`, `ofNew`) 및 엔티티 필드 정의
- 마커 조회 기능 구현
  - `LoadMakerPort`, `LoadMakerAdapter`, `GetMakerInfoService` 및 `GetMakerInfoController` 추가
  - GET `/v1/makers/{makerId}` 엔드포인트 구현
- 마커 수정 기능 구현
  - `UpdateMakerCommand`, `UpdateMakerAdapter`, `UpdateMakerService`, `UpdateMakerController` 추가
  - PUT `/v1/makers/{makerId}` 엔드포인트 구현
- 마커 삭제 기능 구현
  - `DeleteMakerCommand`, `DeleteMakerAdapter`, `DeleteMakerService`, `DeleteMakerController` 추가
  - DELETE `/v1/makers/{makerId}` 엔드포인트 구현

## 🧪 테스트 방법

```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [ ] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- 현재는 구조만 보시면 될 것 같습니다

## 💬 기타 코멘트

- 이슈는 분리할 예정입니다


