### PR TITLE
[FEAT] #20 비용 기본 CURD 구현

### DIFF
--- a/src/docs/asciidoc/api/expense/create-expense.adoc
+++ b/src/docs/asciidoc/api/expense/create-expense.adoc
@@ -1,0 +1,11 @@
+[[create-expense]]
+=== 비용 생성
+
+==== HTTP Request
+
+include::{snippets}/create-expense/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/create-expense/http-response.adoc[]
+include::{snippets}/create-expense/response-fields.adoc[]

--- a/src/docs/asciidoc/api/expense/delete-expense.adoc
+++ b/src/docs/asciidoc/api/expense/delete-expense.adoc
@@ -1,0 +1,11 @@
+[[delete-expense]]
+=== 비용 삭제
+
+==== HTTP Request
+
+include::{snippets}/delete-expense/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/delete-expense/http-response.adoc[]
+include::{snippets}/delete-expense/response-fields.adoc[]

--- a/src/docs/asciidoc/api/expense/get-expense-info.adoc
+++ b/src/docs/asciidoc/api/expense/get-expense-info.adoc
@@ -1,0 +1,11 @@
+[[get-expense-info]]
+=== 비용 정보 조회
+
+==== HTTP Request
+
+include::{snippets}/get-expense/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/get-expense/http-response.adoc[]
+include::{snippets}/get-expense/response-fields.adoc[]

--- a/src/docs/asciidoc/api/expense/update-expense.adoc
+++ b/src/docs/asciidoc/api/expense/update-expense.adoc
@@ -1,0 +1,12 @@
+[[update-expense]]
+=== 비용 수정
+
+==== HTTP Request
+
+include::{snippets}/update-expense/http-request.adoc[]
+include::{snippets}/update-expense/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/update-expense/http-response.adoc[]
+include::{snippets}/update-expense/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,3 +16,13 @@ include::api/group/create-group.adoc[]
 include::api/group/get-group-info.adoc[]
 include::api/group/update-group.adoc[]
 include::api/group/delete-group.adoc[]
+
+[[expense-API]]
+== Expense API
+
+include::api/expense/create-expense.adoc[]
+include::api/expense/get-expense-info.adoc[]
+include::api/expense/update-expense.adoc[]
+include::api/expense/delete-expense.adoc[]
+
+``

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/CreateExpenseController.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/CreateExpenseController.java
@@ -1,0 +1,36 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.expense.adapter.in.web.request.CreateExpenseRequest;
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.CreateExpenseResponse;
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 비용 생성 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class CreateExpenseController {
+
+    private final CreateExpenseUseCase createExpenseUseCase;
+
+    /**
+     * 비용 생성 요청을 처리합니다.
+     *
+     * @param request 비용 생성 요청 데이터
+     * @return 생성된 비용 정보
+     */
+    @PostMapping("/v1/expenses")
+    public CreateExpenseResponse createExpense(@RequestBody CreateExpenseRequest request) {
+        return createExpenseUseCase.createExpense(CreateExpenseCommand.builder()
+            .billingDetails(request.billingDetails())
+            .price(request.price())
+            .build());
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/DeleteExpenseController.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/DeleteExpenseController.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.expense.application.port.in.DeleteExpenseUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 비용 삭제 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class DeleteExpenseController {
+
+    private final DeleteExpenseUseCase deleteExpenseUseCase;
+
+    /**
+     * 비용을 삭제합니다.
+     *
+     * @param expenseId 삭제할 비용 ID
+     * @return 삭제 성공 여부
+     */
+    @DeleteMapping("/v1/expenses/{expenseId}")
+    public Boolean deleteExpense(@PathVariable Long expenseId) {
+        return deleteExpenseUseCase.deleteExpense(expenseId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/GetExpenseInfoController.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/GetExpenseInfoController.java
@@ -1,0 +1,31 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.GetExpenseInfoResponse;
+import com.readysetgo.traveltracker.expense.application.port.in.GetExpenseInfoQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 비용 조회 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class GetExpenseInfoController {
+
+    private final GetExpenseInfoQuery getExpenseInfoQuery;
+
+    /**
+     * 비용 정보를 조회합니다.
+     *
+     * @param expenseId 조회할 비용 ID
+     * @return 비용 정보
+     */
+    @GetMapping("/v1/expenses/{expenseId}")
+    public GetExpenseInfoResponse getExpenseInfo(@PathVariable Long expenseId) {
+        return getExpenseInfoQuery.getExpenseInfo(expenseId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/UpdateExpenseController.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/UpdateExpenseController.java
@@ -1,0 +1,41 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.expense.adapter.in.web.request.UpdateExpenseRequest;
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 비용 수정 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class UpdateExpenseController {
+
+    private final UpdateExpenseUseCase updateExpenseUseCase;
+
+    /**
+     * 비용 정보를 수정합니다.
+     *
+     * @param expenseId 수정할 비용 ID
+     * @param request   수정 요청 데이터
+     * @return 수정 성공 여부
+     */
+    @PutMapping("/v1/expenses/{expenseId}")
+    public Boolean updateExpense(
+        @PathVariable Long expenseId,
+        @RequestBody UpdateExpenseRequest request
+    ) {
+        return updateExpenseUseCase.updateExpense(UpdateExpenseCommand.builder()
+            .expenseId(expenseId)
+            .billingDetails(request.billingDetails())
+            .price(request.price())
+            .build());
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/request/CreateExpenseRequest.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/request/CreateExpenseRequest.java
@@ -1,0 +1,14 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web.request;
+
+import lombok.Builder;
+
+/**
+ * 비용 생성 요청 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record CreateExpenseRequest(
+    String billingDetails, // 결제 세부 정보
+    Double price           // 비용 금액
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/request/UpdateExpenseRequest.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/request/UpdateExpenseRequest.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web.request;
+
+import lombok.Builder;
+
+/**
+ * 비용 수정 요청 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record UpdateExpenseRequest(
+    Long expenseId,        // 비용 ID
+    String billingDetails, // 수정할 결제 세부 정보
+    Double price           // 수정할 비용 금액
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/response/CreateExpenseResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/response/CreateExpenseResponse.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web.response;
+
+import lombok.Builder;
+
+/**
+ * 비용 생성 응답 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record CreateExpenseResponse(
+    Long expenseId,        // 생성된 비용 ID
+    String billingDetails, // 결제 세부 정보
+    Double price           // 비용 금액
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/response/GetExpenseInfoResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/in/web/response/GetExpenseInfoResponse.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.expense.adapter.in.web.response;
+
+import lombok.Builder;
+
+/**
+ * 비용 조회 응답 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record GetExpenseInfoResponse(
+    Long expenseId,        // 비용 ID
+    String billingDetails, // 결제 세부 정보
+    Double price           // 비용 금액
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/CreateExpenseAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/CreateExpenseAdapter.java
@@ -1,0 +1,33 @@
+package com.readysetgo.traveltracker.expense.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseJpaEntity;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseRepository;
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.out.CreateExpensePort;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 비용 데이터를 영속성 계층에 저장하는 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class CreateExpenseAdapter implements CreateExpensePort {
+
+    private final ExpenseRepository expenseRepository;
+
+    @Override
+    public Long createExpense(CreateExpenseCommand command) {
+        ExpenseJpaEntity expense = createExpenseEntity(command);
+        expenseRepository.save(expense);
+
+        return expense.getId();
+    }
+
+    private ExpenseJpaEntity createExpenseEntity(CreateExpenseCommand command) {
+        return ExpenseJpaEntity.builder()
+            .billingDetails(command.billingDetails())
+            .price(command.price())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/DeleteExpenseAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/DeleteExpenseAdapter.java
@@ -1,0 +1,22 @@
+package com.readysetgo.traveltracker.expense.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseRepository;
+import com.readysetgo.traveltracker.expense.application.port.out.DeleteExpensePort;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 비용 데이터를 삭제하기 위한 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class DeleteExpenseAdapter implements DeleteExpensePort {
+
+    private final ExpenseRepository expenseRepository;
+
+    @Override
+    public Boolean deleteExpense(Long expenseId) {
+        expenseRepository.deleteById(expenseId);
+        return true; //TODO: 필요시 요청에 따른 응답으로 변경
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/LoadExpenseAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/LoadExpenseAdapter.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.expense.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseJpaEntity;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseRepository;
+import com.readysetgo.traveltracker.expense.application.port.out.LoadExpensePort;
+import com.readysetgo.traveltracker.expense.domain.Expense;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 비용 데이터를 조회하기 위한 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LoadExpenseAdapter implements LoadExpensePort {
+
+    private final ExpenseRepository expenseRepository;
+
+    @Override
+    public Expense loadExpense(Long expenseId) {
+        ExpenseJpaEntity expense = expenseRepository.findById(expenseId)
+            .orElseThrow(RuntimeException::new); // TODO: 적절한 커스텀 예외로 변경, 현재 500 발생
+
+        return Expense.builder()
+            .id(expense.getId())
+            .billingDetails(expense.getBillingDetails())
+            .price(expense.getPrice())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/UpdateExpenseAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/UpdateExpenseAdapter.java
@@ -1,0 +1,28 @@
+package com.readysetgo.traveltracker.expense.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseJpaEntity;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseRepository;
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.out.UpdateExpensePort;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 비용 데이터를 수정하기 위한 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class UpdateExpenseAdapter implements UpdateExpensePort {
+
+    private final ExpenseRepository expenseRepository;
+
+    @Override
+    public boolean updateExpense(UpdateExpenseCommand command) {
+        ExpenseJpaEntity expense = expenseRepository.findById(command.expenseId())
+            .orElseThrow(RuntimeException::new); // TODO: 적절한 커스텀 예외로 변경 현재 500 반환
+
+        expense.updateInfo(command.billingDetails(), command.price());
+
+        return true; //TODO: 필요시 적절한 내용으로 변경
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/persistence/ExpenseJpaEntity.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/persistence/ExpenseJpaEntity.java
@@ -1,0 +1,52 @@
+package com.readysetgo.traveltracker.expense.adapter.out.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 비용 정보를 나타내는 JPA 엔터티 클래스입니다. 데이터베이스의 `EXPENSE` 테이블과 매핑됩니다.
+ */
+@Entity
+@Table(name = "EXPENSE")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 요구사항에 따라 기본 생성자 제한
+public class ExpenseJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 비용 ID (Primary Key)
+
+    private String billingDetails; // 결제 세부 정보
+
+    private Double price; // 비용 금액
+
+    /**
+     * 엔터티 생성자.
+     *
+     * @param billingDetails 결제 세부 정보
+     * @param price          비용 금액
+     */
+    @Builder
+    private ExpenseJpaEntity(String billingDetails, Double price) {
+        this.billingDetails = billingDetails;
+        this.price = price;
+    }
+
+    /**
+     * 비용 정보를 업데이트하는 메서드.
+     *
+     * @param billingDetails 새 결제 세부 정보
+     * @param price          새 비용 금액
+     */
+    public void updateInfo(String billingDetails, Double price) {
+        this.billingDetails = billingDetails;
+        this.price = price;
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/persistence/ExpenseRepository.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/adapter/out/persistence/ExpenseRepository.java
@@ -1,0 +1,10 @@
+package com.readysetgo.traveltracker.expense.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 비용 엔터티와 데이터베이스 간의 CRUD 작업을 수행하는 JPA 리포지토리 인터페이스입니다.
+ */
+public interface ExpenseRepository extends JpaRepository<ExpenseJpaEntity, Long> {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/CreateExpenseCommand.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/CreateExpenseCommand.java
@@ -1,0 +1,14 @@
+package com.readysetgo.traveltracker.expense.application.port.in;
+
+import lombok.Builder;
+
+/**
+ * 비용 생성 비즈니스 로직에 필요한 데이터를 전달하는 명령 객체입니다.
+ */
+@Builder
+public record CreateExpenseCommand(
+    String billingDetails, // 결제 세부 정보
+    Double price           // 비용 금액
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/CreateExpenseUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/CreateExpenseUseCase.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.expense.application.port.in;
+
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.CreateExpenseResponse;
+
+/**
+ * 비용 생성 유스케이스 인터페이스입니다.
+ */
+public interface CreateExpenseUseCase {
+
+    /**
+     * 비용을 생성합니다.
+     *
+     * @param command 비용 생성 명령 객체
+     * @return 생성된 비용 정보
+     */
+    CreateExpenseResponse createExpense(CreateExpenseCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/DeleteExpenseUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/DeleteExpenseUseCase.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.expense.application.port.in;
+
+/**
+ * 비용 삭제 유스케이스 인터페이스입니다.
+ */
+public interface DeleteExpenseUseCase {
+
+    /**
+     * 비용을 삭제합니다.
+     *
+     * @param expenseId 삭제할 비용 ID
+     * @return 삭제 성공 여부
+     */
+    boolean deleteExpense(Long expenseId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/GetExpenseInfoQuery.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/GetExpenseInfoQuery.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.expense.application.port.in;
+
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.GetExpenseInfoResponse;
+
+/**
+ * 비용 조회 유스케이스 인터페이스입니다.
+ */
+public interface GetExpenseInfoQuery {
+
+    /**
+     * 비용 정보를 조회합니다.
+     *
+     * @param expenseId 조회할 비용 ID
+     * @return 비용 정보 응답 객체
+     */
+    GetExpenseInfoResponse getExpenseInfo(Long expenseId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/UpdateExpenseCommand.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/UpdateExpenseCommand.java
@@ -1,0 +1,16 @@
+package com.readysetgo.traveltracker.expense.application.port.in;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+/**
+ * 비용 수정 비즈니스 로직에 필요한 데이터를 전달하는 명령 객체입니다.
+ */
+@Builder
+public record UpdateExpenseCommand(
+    @NotNull Long expenseId,        // 수정할 비용 ID
+    @NotNull String billingDetails, // 수정할 결제 세부 정보
+    @NotNull Double price           // 수정할 비용 금액
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/UpdateExpenseUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/in/UpdateExpenseUseCase.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.expense.application.port.in;
+
+/**
+ * 비용 수정 유스케이스 인터페이스입니다.
+ */
+public interface UpdateExpenseUseCase {
+
+    /**
+     * 비용 정보를 수정합니다.
+     *
+     * @param command 비용 수정 명령 객체
+     * @return 수정 성공 여부
+     */
+    boolean updateExpense(UpdateExpenseCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/CreateExpensePort.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/CreateExpensePort.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.expense.application.port.out;
+
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseCommand;
+
+/**
+ * 비용 생성 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface CreateExpensePort {
+
+    /**
+     * 비용을 생성합니다.
+     *
+     * @param command 비용 생성 명령 객체
+     * @return 생성된 비용 ID
+     */
+    Long createExpense(CreateExpenseCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/DeleteExpensePort.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/DeleteExpensePort.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.expense.application.port.out;
+
+/**
+ * 비용 삭제 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface DeleteExpensePort {
+
+    /**
+     * 비용 데이터를 삭제합니다.
+     *
+     * @param expenseId 삭제할 비용 ID
+     * @return 삭제 성공 여부
+     */
+    Boolean deleteExpense(Long expenseId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/LoadExpensePort.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/LoadExpensePort.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.expense.application.port.out;
+
+import com.readysetgo.traveltracker.expense.domain.Expense;
+
+/**
+ * 비용 조회 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface LoadExpensePort {
+
+    /**
+     * 비용 데이터를 조회합니다.
+     *
+     * @param expenseId 조회할 비용 ID
+     * @return 비용 도메인 객체
+     */
+    Expense loadExpense(Long expenseId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/UpdateExpensePort.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/port/out/UpdateExpensePort.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.expense.application.port.out;
+
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseCommand;
+
+/**
+ * 비용 수정 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface UpdateExpensePort {
+
+    /**
+     * 비용 데이터를 수정합니다.
+     *
+     * @param command 비용 수정 명령 객체
+     * @return 수정 성공 여부
+     */
+    boolean updateExpense(UpdateExpenseCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/service/CreateExpenseService.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/service/CreateExpenseService.java
@@ -1,0 +1,29 @@
+package com.readysetgo.traveltracker.expense.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.CreateExpenseResponse;
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseUseCase;
+import com.readysetgo.traveltracker.expense.application.port.out.CreateExpensePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 비용 생성 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateExpenseService implements CreateExpenseUseCase {
+
+    private final CreateExpensePort createExpensePort;
+
+    @Override
+    public CreateExpenseResponse createExpense(CreateExpenseCommand command) {
+        return CreateExpenseResponse.builder()
+            .expenseId(createExpensePort.createExpense(command))
+            .billingDetails(command.billingDetails())
+            .price(command.price())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/service/DeleteExpenseService.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/service/DeleteExpenseService.java
@@ -1,0 +1,23 @@
+package com.readysetgo.traveltracker.expense.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.expense.application.port.in.DeleteExpenseUseCase;
+import com.readysetgo.traveltracker.expense.application.port.out.DeleteExpensePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 비용 삭제 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class DeleteExpenseService implements DeleteExpenseUseCase {
+
+    private final DeleteExpensePort deleteExpensePort;
+
+    @Override
+    public boolean deleteExpense(Long expenseId) {
+        return deleteExpensePort.deleteExpense(expenseId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/service/GetExpenseInfoService.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/service/GetExpenseInfoService.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.expense.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.GetExpenseInfoResponse;
+import com.readysetgo.traveltracker.expense.application.port.in.GetExpenseInfoQuery;
+import com.readysetgo.traveltracker.expense.application.port.out.LoadExpensePort;
+import com.readysetgo.traveltracker.expense.domain.Expense;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 비용 조회 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetExpenseInfoService implements GetExpenseInfoQuery {
+
+    private final LoadExpensePort loadExpensePort;
+
+    @Override
+    public GetExpenseInfoResponse getExpenseInfo(Long expenseId) {
+        Expense expense = loadExpensePort.loadExpense(expenseId);
+        return GetExpenseInfoResponse.builder()
+            .expenseId(expense.getId())
+            .billingDetails(expense.getBillingDetails())
+            .price(expense.getPrice())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/application/service/UpdateExpenseService.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/application/service/UpdateExpenseService.java
@@ -1,0 +1,24 @@
+package com.readysetgo.traveltracker.expense.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseUseCase;
+import com.readysetgo.traveltracker.expense.application.port.out.UpdateExpensePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 비용 수정 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class UpdateExpenseService implements UpdateExpenseUseCase {
+
+    private final UpdateExpensePort updateExpensePort;
+
+    @Override
+    public boolean updateExpense(UpdateExpenseCommand command) {
+        return updateExpensePort.updateExpense(command);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/expense/domain/Expense.java
+++ b/src/main/java/com/readysetgo/traveltracker/expense/domain/Expense.java
@@ -1,0 +1,18 @@
+package com.readysetgo.traveltracker.expense.domain;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+@Builder
+public class Expense {
+
+    private final String billingDetails;
+    private final Double price;
+    ;
+    private Long id;
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
@@ -1,0 +1,89 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import com.readysetgo.traveltracker.common.helper.util.ArbitraryField;
+import com.readysetgo.traveltracker.expense.adapter.in.web.request.CreateExpenseRequest;
+import com.readysetgo.traveltracker.expense.adapter.in.web.request.UpdateExpenseRequest;
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.CreateExpenseResponse;
+import com.readysetgo.traveltracker.expense.adapter.in.web.response.GetExpenseInfoResponse;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseJpaEntity;
+
+/**
+ * API 테스트에서 사용되는 요청 및 응답 객체를 생성하는 헬퍼 클래스입니다.
+ * <p>
+ * 테스트 시 반복적으로 생성되는 객체를 미리 정의하여, 테스트의 간결성과 가독성을 높입니다.
+ * </p>
+ */
+public class ArbitraryFactory {
+
+    /**
+     * 비용(Expense) 관련 요청 및 응답 객체 생성을 위한 내부 클래스입니다.
+     */
+    public static class Expense {
+
+        /**
+         * 미리 정의된 비용 생성 요청 객체입니다.
+         * <p>
+         * 테스트에서 비용 생성 요청 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final CreateExpenseRequest aCreateExpenseRequest =
+            CreateExpenseRequest.builder()
+                .billingDetails(ArbitraryField.Expense.BILLING_DETAILS)
+                .price(ArbitraryField.Expense.PRICE)
+                .build();
+
+        /**
+         * 미리 정의된 비용 생성 응답 객체입니다.
+         * <p>
+         * 테스트에서 비용 생성 결과 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final CreateExpenseResponse aCreateExpenseResponse =
+            CreateExpenseResponse.builder()
+                .expenseId(ArbitraryField.Expense.EXPENSE_ID)
+                .billingDetails(ArbitraryField.Expense.BILLING_DETAILS)
+                .price(ArbitraryField.Expense.PRICE)
+                .build();
+
+        /**
+         * 미리 정의된 비용 수정 요청 객체입니다.
+         * <p>
+         * 테스트에서 비용 수정 요청 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final UpdateExpenseRequest aUpdateExpenseRequest =
+            UpdateExpenseRequest.builder()
+                .expenseId(ArbitraryField.Expense.EXPENSE_ID)
+                .billingDetails("Updated " + ArbitraryField.Expense.BILLING_DETAILS)
+                .price(ArbitraryField.Expense.PRICE + 500.0) // 예시로 금액 증가
+                .build();
+
+        /**
+         * 미리 정의된 비용 정보 조회 응답 객체입니다.
+         * <p>
+         * 테스트에서 비용 조회 결과 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final GetExpenseInfoResponse aGetExpenseInfoResponse =
+            GetExpenseInfoResponse.builder()
+                .expenseId(ArbitraryField.Expense.EXPENSE_ID)
+                .price(ArbitraryField.Expense.PRICE)
+                .billingDetails(ArbitraryField.Expense.BILLING_DETAILS)
+                .build();
+
+        /**
+         * 미리 정의된 `ExpenseJpaEntity` 객체를 생성합니다.
+         * <p>
+         * 테스트에서 JPA 엔터티를 필요로 하는 경우에 활용됩니다.
+         * </p>
+         *
+         * @return 미리 정의된 `ExpenseJpaEntity` 객체
+         */
+        public static ExpenseJpaEntity anExpenseJpaEntity() {
+            return ExpenseJpaEntity.builder()
+                .billingDetails(ArbitraryField.Expense.BILLING_DETAILS)
+                .price(ArbitraryField.Expense.PRICE)
+                .build();
+        }
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
@@ -1,0 +1,119 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Expense;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NULL;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.ResultHandler;
+
+/**
+ * API 문서화를 위한 헬퍼 클래스입니다.
+ * <p>
+ * 각종 도메인 API의 요청 및 응답 필드를 문서화하여 Spring REST Docs를 통해 API 문서를 생성할 수 있도록 지원합니다.
+ * </p>
+ */
+public class DocsHelper {
+
+    public static class ExpenseDocs {
+
+        /**
+         * 비용 생성 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 비용 생성 요청과 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 비용 생성 API의 요청/응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler createExpenseDocumentation() {
+            return MockMvcRestDocumentation.document(Expense.DOC_SECTION_CREATE_EXPENSE,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("billingDetails").type(STRING).description("비용 제목"),
+                    fieldWithPath("price").type(NUMBER).description("비용 금액")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data.billingDetails").type(STRING).description("비용 제목"),
+                    fieldWithPath("data.price").type(NUMBER).description("비용 금액"),
+                    fieldWithPath("data.expenseId").type(NUMBER).description("생성된 비용 ID"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 비용 조회 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 비용 조회 요청에 대한 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 비용 조회 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler getExpenseDocumentation() {
+            return MockMvcRestDocumentation.document(Expense.DOC_SECTION_GET_EXPENSE,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").description("응답 상태"),
+                    fieldWithPath("data.expenseId").description("비용 ID"),
+                    fieldWithPath("data.price").description("가격"),
+                    fieldWithPath("data.billingDetails").description("청구 상세 정보"),
+                    fieldWithPath("error").description("오류 정보").optional()
+                )
+            );
+        }
+
+        /**
+         * 비용 수정 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 비용 수정 요청과 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 비용 수정 API의 요청/응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler updateExpenseDocumentation() {
+            return MockMvcRestDocumentation.document(Expense.DOC_SECTION_UPDATE_EXPENSE,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("expenseId").type(NUMBER).description("수정할 비용 ID"),
+                    fieldWithPath("billingDetails").type(STRING).description("수정할 비용 제목"),
+                    fieldWithPath("price").type(NUMBER).description("수정할 비용 금액")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data").type(BOOLEAN).description("수정 성공 여부"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 비용 삭제 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 비용 삭제 요청에 대한 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 비용 삭제 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler deleteExpenseDocumentation() {
+            return MockMvcRestDocumentation.document(Expense.DOC_SECTION_DELETE_EXPENSE,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data").type(BOOLEAN).description("삭제 성공 여부"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
@@ -1,0 +1,66 @@
+package com.readysetgo.traveltracker.common.helper.util;
+
+/**
+ * API 테스트에서 사용되는 임의의 필드 값을 정의한 클래스입니다.
+ * <p>
+ * 각종 도메인 관련 요청 및 응답 필드 값, URL, 문서화 섹션명을 포함하고 있어 테스트 및 문서화 설정 시 활용됩니다.
+ * </p>
+ */
+public class ArbitraryField {
+
+    /**
+     * 비용(Expense) 관련 임의의 필드 값과 URL을 정의한 내부 클래스입니다.
+     */
+    public static class Expense {
+
+        /**
+         * 임의의 비용 ID
+         */
+        public static final Long ID = 56L;
+
+        /**
+         * 비용 API의 기본 URL
+         */
+        public static final String EXPENSE_BASE_URL = "/v1/expenses";
+
+        /**
+         * 비용 ID를 포함한 상세 조회 URL
+         */
+        public static final String EXPENSE_ID_URL = EXPENSE_BASE_URL + "/{id}";
+
+        /**
+         * 비용 생성 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_CREATE_EXPENSE = "create-expense";
+
+        /**
+         * 비용 조회 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_GET_EXPENSE = "get-expense";
+
+        /**
+         * 비용 수정 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_UPDATE_EXPENSE = "update-expense";
+
+        /**
+         * 비용 삭제 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_DELETE_EXPENSE = "delete-expense";
+
+        /**
+         * 임의의 비용 금액
+         */
+        public static final Double PRICE = 30000.0;
+
+        /**
+         * 임의의 결제 세부 정보
+         */
+        public static final String BILLING_DETAILS = "쌀국수";
+
+        /**
+         * 임의의 비용 ID (특정 테스트용)
+         */
+        public static final Long EXPENSE_ID = 1L;
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/docs/ExpenseControllerDocsTest.java
+++ b/src/test/java/com/readysetgo/traveltracker/docs/ExpenseControllerDocsTest.java
@@ -1,0 +1,165 @@
+package com.readysetgo.traveltracker.docs;
+
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Expense.aCreateExpenseRequest;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Expense.aCreateExpenseResponse;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Expense.aGetExpenseInfoResponse;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Expense.aUpdateExpenseRequest;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.ExpenseDocs.createExpenseDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.ExpenseDocs.deleteExpenseDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.ExpenseDocs.getExpenseDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.ExpenseDocs.updateExpenseDocumentation;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Expense.EXPENSE_BASE_URL;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Expense.EXPENSE_ID_URL;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Expense.ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.in.CreateExpenseUseCase;
+import com.readysetgo.traveltracker.expense.application.port.in.DeleteExpenseUseCase;
+import com.readysetgo.traveltracker.expense.application.port.in.GetExpenseInfoQuery;
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseCommand;
+import com.readysetgo.traveltracker.expense.application.port.in.UpdateExpenseUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+/**
+ * 비용 API에 대한 REST Docs 테스트 클래스입니다.
+ * <p>
+ * 비용 생성, 조회, 수정, 삭제 요청의 API 문서화를 위해 MockMVC와 REST Docs를 이용해 요청 및 응답 필드를 문서화하고 예제 테스트 케이스를 제공합니다.
+ * </p>
+ */
+@DisplayName("비용 API 문서 생성 테스트")
+public class ExpenseControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private CreateExpenseUseCase createExpenseUseCase;
+
+    @MockBean
+    private GetExpenseInfoQuery getExpenseInfoQuery;
+
+    @MockBean
+    private UpdateExpenseUseCase updateExpenseUseCase;
+
+    @MockBean
+    private DeleteExpenseUseCase deleteExpenseUseCase;
+
+    /**
+     * 비용 생성 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("비용 생성 요청")
+    class CreateExpense {
+
+        /**
+         * 유효한 비용 생성 요청 시 성공적으로 비용가 생성되고, API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("비용 생성 성공")
+        void validExpenseRequest_createsExpense_returnsCreatedStatus() throws Exception {
+            given(createExpenseUseCase.createExpense(any(CreateExpenseCommand.class)))
+                .willReturn(aCreateExpenseResponse);
+
+            String body = objectMapper.writeValueAsString(aCreateExpenseRequest);
+
+            ResultActions perform = mockMvc.perform(post(EXPENSE_BASE_URL)
+                .contentType(APPLICATION_JSON)
+                .content(body));
+            perform
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 201로 수정 필요
+                .andDo(createExpenseDocumentation());
+        }
+    }
+
+    /**
+     * 비용 조회 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("비용 조회 요청")
+    class GetExpenseInfo {
+
+        /**
+         * 존재하는 비용 ID로 요청 시, 비용 정보를 성공적으로 조회하고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("비용 조회 성공")
+        void existingExpenseId_retrievesExpense_returnsExpenseDetails() throws Exception {
+            given(getExpenseInfoQuery.getExpenseInfo(anyLong()))
+                .willReturn(aGetExpenseInfoResponse);
+
+            mockMvc.perform(get(EXPENSE_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(getExpenseDocumentation());
+        }
+    }
+
+    /**
+     * 비용 수정 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("비용 수정 요청")
+    class UpdateExpense {
+
+        /**
+         * 유효한 비용 수정 요청 시 성공적으로 비용가 수정되고, API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("비용 수정 성공")
+        void validUpdateRequest_updatesExpense_returnsOkStatus() throws Exception {
+            given(updateExpenseUseCase.updateExpense(any(UpdateExpenseCommand.class)))
+                .willReturn(true);
+
+            String body = objectMapper.writeValueAsString(aUpdateExpenseRequest);
+
+            mockMvc.perform(put(EXPENSE_ID_URL, ID)
+                    .contentType(APPLICATION_JSON)
+                    .content(body))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(updateExpenseDocumentation());
+        }
+    }
+
+    /**
+     * 비용 삭제 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("비용 삭제 요청")
+    class DeleteExpense {
+
+        /**
+         * 존재하는 비용 ID로 삭제 요청 시, 성공적으로 비용가 삭제되고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("비용 삭제 성공")
+        void existingExpenseId_deletesExpense_returnsNoContentStatus() throws Exception {
+            given(deleteExpenseUseCase.deleteExpense(anyLong())).willReturn(true);
+
+            mockMvc.perform(delete(EXPENSE_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 204로 수정 필요
+                .andDo(deleteExpenseDocumentation());
+        }
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/expense/adapter/out/LoadExpenseAdapterTest.java
+++ b/src/test/java/com/readysetgo/traveltracker/expense/adapter/out/LoadExpenseAdapterTest.java
@@ -1,0 +1,61 @@
+package com.readysetgo.traveltracker.expense.adapter.out;
+
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Expense.anExpenseJpaEntity;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseJpaEntity;
+import com.readysetgo.traveltracker.expense.adapter.out.persistence.ExpenseRepository;
+import com.readysetgo.traveltracker.expense.domain.Expense;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * {@link LoadExpenseAdapter}에 대한 통합 테스트 클래스입니다.
+ * <p>
+ * 이 클래스는 데이터베이스와의 실제 상호작용을 통해 어댑터의 동작을 검증합니다.
+ * </p>
+ */
+@SpringBootTest
+class LoadExpenseAdapterTest {
+
+    @Autowired
+    private LoadExpenseAdapter loadExpenseAdapter;
+
+    @Autowired
+    private ExpenseRepository expenseRepository;
+
+    /**
+     * 각 테스트 후 데이터 정리를 수행합니다.
+     */
+    @AfterEach
+    void tearDown() {
+        expenseRepository.deleteAllInBatch(); // 데이터 정리
+    }
+
+    /**
+     * 어댑터를 사용하여 데이터베이스에서 비용 정보를 불러오는 테스트입니다.
+     */
+    @DisplayName("데이터베이스에 저장된 비용을 어댑터로 불러올 때 유효한 비용 반환")
+    @Test
+    void expenseSavedInDatabase_loadedThroughAdapter_returnsValidExpense() {
+        // given
+        ExpenseJpaEntity expenseEntity = anExpenseJpaEntity();
+        expenseRepository.save(expenseEntity);
+
+        // when
+        Expense expense = loadExpenseAdapter.loadExpense(expenseEntity.getId());
+
+        // then
+        assertThat(expense, is(notNullValue())); // 객체가 null이 아님을 확인
+        assertThat(expense.getId(), is(equalTo(expenseEntity.getId())));
+        assertThat(expense.getPrice(), is(closeTo(expenseEntity.getPrice(), 0.01)));
+        assertThat(expense.getBillingDetails(), is(equalTo(expenseEntity.getBillingDetails())));
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #20 

## 📌 PR 요약

- 비용(Expense) 도메인을 정의 
- 타 도메인 연관관계를 제외한 CRUD 기능 구현 및 관련 API 문서를 작성

## 🔍 주요 변경 사항

- **비용 도메인 정의**
  - 비용 정보를 나타내는 `Expense` 클래스 추가
    - `id`, `billingDetails`, `price` 필드 포함
- **비용 JPA 설정 추가**
  - 비용 엔티티 및 리포지토리 정의
  - DB 매핑 및 기본 쿼리 기능 제공
- **비용 CRUD 기능 구현**
  - **Create**: 비용 생성 API 및 저장 로직 구현
  - **Read**: 비용 조회 API 및 데이터 로드 어댑터 구현
  - **Update**: 비용 업데이트 API 및 수정 로직 분리
  - **Delete**: 비용 삭제 API 및 요청 처리 로직 구현
- **비용 테스트 추가**
  - CRUD 기능별 API 테스트 작성
  - 테스트 데이터 생성을 위한 헬퍼 클래스 추가
  - 어댑터 동작 검증 테스트 작성
- **비용 API 문서화**
  - REST Docs를 활용하여 CRUD API 요청/응답 스펙 정의

## 🧪 테스트 방법

```
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- 응답 관련 수정 `TODO` 내용은 추후 요구사항에 적용할 예정입니다.
- 테스트 코드의 예외 및 BeanValidation 관련 필드 검증내용은 추후 추가 예정입니다.
- 타 도메인 연관관계는 추후 추가 예정입니다 