### PR TITLE
[FEAT] #22 채무자 기본 CRD 구현

### DIFF
--- a/src/docs/asciidoc/api/debtor/create-debtor.adoc
+++ b/src/docs/asciidoc/api/debtor/create-debtor.adoc
@@ -1,0 +1,11 @@
+[[create-debtor]]
+=== 채무자 생성
+
+==== HTTP Request
+
+include::{snippets}/create-debtor/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/create-debtor/http-response.adoc[]
+include::{snippets}/create-debtor/response-fields.adoc[]

--- a/src/docs/asciidoc/api/debtor/delete-debtor.adoc
+++ b/src/docs/asciidoc/api/debtor/delete-debtor.adoc
@@ -1,0 +1,11 @@
+[[delete-debtor]]
+=== 채무자 삭제
+
+==== HTTP Request
+
+include::{snippets}/delete-debtor/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/delete-debtor/http-response.adoc[]
+include::{snippets}/delete-debtor/response-fields.adoc[]

--- a/src/docs/asciidoc/api/debtor/get-debtor-info.adoc
+++ b/src/docs/asciidoc/api/debtor/get-debtor-info.adoc
@@ -1,0 +1,11 @@
+[[get-debtor-info]]
+=== 채무자 정보 조회
+
+==== HTTP Request
+
+include::{snippets}/get-debtor/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/get-debtor/http-response.adoc[]
+include::{snippets}/get-debtor/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,3 +16,10 @@ include::api/group/create-group.adoc[]
 include::api/group/get-group-info.adoc[]
 include::api/group/update-group.adoc[]
 include::api/group/delete-group.adoc[]
+
+[[debtor-API]]
+== Debtor API
+
+include::api/debtor/create-debtor.adoc[]
+include::api/debtor/get-debtor-info.adoc[]
+include::api/debtor/delete-debtor.adoc[]

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/CreateDebtorController.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/CreateDebtorController.java
@@ -1,0 +1,34 @@
+package com.readysetgo.traveltracker.debtor.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.request.CreateDebtorRequest;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.CreateDebtorResponse;
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorCommand;
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 채무자 생성 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class CreateDebtorController {
+
+    private final CreateDebtorUseCase createDebtorUseCase;
+
+    /**
+     * 채무자 생성 요청을 처리합니다.
+     *
+     * @param request 채무자 생성 요청 데이터
+     * @return 생성된 채무자 정보
+     */
+    @PostMapping("/v1/debtors")
+    public CreateDebtorResponse createDebtor(@RequestBody CreateDebtorRequest request) {
+        return createDebtorUseCase.createDebtor(CreateDebtorCommand.builder()
+            .build());
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/DeleteDebtorController.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/DeleteDebtorController.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.debtor.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.debtor.application.port.in.DeleteDebtorUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 채무자 삭제 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class DeleteDebtorController {
+
+    private final DeleteDebtorUseCase deleteDebtorUseCase;
+
+    /**
+     * 채무자을 삭제합니다.
+     *
+     * @param debtorId 삭제할 채무자 ID
+     * @return 삭제 성공 여부
+     */
+    @DeleteMapping("/v1/debtors/{debtorId}")
+    public Boolean deleteDebtor(@PathVariable Long debtorId) {
+        return deleteDebtorUseCase.deleteDebtor(debtorId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/GetDebtorInfoController.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/GetDebtorInfoController.java
@@ -1,0 +1,31 @@
+package com.readysetgo.traveltracker.debtor.adapter.in.web;
+
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.GetDebtorInfoResponse;
+import com.readysetgo.traveltracker.debtor.application.port.in.GetDebtorInfoQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 채무자 조회 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class GetDebtorInfoController {
+
+    private final GetDebtorInfoQuery getDebtorInfoQuery;
+
+    /**
+     * 채무자 정보를 조회합니다.
+     *
+     * @param debtorId 조회할 채무자 ID
+     * @return 채무자 정보
+     */
+    @GetMapping("/v1/debtors/{debtorId}")
+    public GetDebtorInfoResponse getDebtorInfo(@PathVariable Long debtorId) {
+        return getDebtorInfoQuery.getDebtorInfo(debtorId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/request/CreateDebtorRequest.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/request/CreateDebtorRequest.java
@@ -1,0 +1,12 @@
+package com.readysetgo.traveltracker.debtor.adapter.in.web.request;
+
+import lombok.Builder;
+
+/**
+ * 채무자 생성 요청 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record CreateDebtorRequest(
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/response/CreateDebtorResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/response/CreateDebtorResponse.java
@@ -1,0 +1,13 @@
+package com.readysetgo.traveltracker.debtor.adapter.in.web.response;
+
+import lombok.Builder;
+
+/**
+ * 채무자 생성 응답 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record CreateDebtorResponse(
+    Long debtorId        // 생성된 채무자 ID
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/response/GetDebtorInfoResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/in/web/response/GetDebtorInfoResponse.java
@@ -1,0 +1,13 @@
+package com.readysetgo.traveltracker.debtor.adapter.in.web.response;
+
+import lombok.Builder;
+
+/**
+ * 채무자 조회 응답 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record GetDebtorInfoResponse(
+    Long debtorId        // 채무자 ID
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/CreateDebtorAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/CreateDebtorAdapter.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.debtor.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorJpaEntity;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorRepository;
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorCommand;
+import com.readysetgo.traveltracker.debtor.application.port.out.CreateDebtorPort;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채무자 데이터를 영속성 계층에 저장하는 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class CreateDebtorAdapter implements CreateDebtorPort {
+
+    private final DebtorRepository debtorRepository;
+
+    @Override
+    public Long createDebtor(CreateDebtorCommand command) {
+        DebtorJpaEntity debtor = createDebtorEntity(command);
+        debtorRepository.save(debtor);
+
+        return debtor.getId();
+    }
+
+    private DebtorJpaEntity createDebtorEntity(CreateDebtorCommand command) {
+        return new DebtorJpaEntity();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/DeleteDebtorAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/DeleteDebtorAdapter.java
@@ -1,0 +1,22 @@
+package com.readysetgo.traveltracker.debtor.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorRepository;
+import com.readysetgo.traveltracker.debtor.application.port.out.DeleteDebtorPort;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채무자 데이터를 삭제하기 위한 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class DeleteDebtorAdapter implements DeleteDebtorPort {
+
+    private final DebtorRepository debtorRepository;
+
+    @Override
+    public Boolean deleteDebtor(Long debtorId) {
+        debtorRepository.deleteById(debtorId);
+        return true; //TODO: 필요시 요청에 따른 응답으로 변경
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/LoadDebtorAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/LoadDebtorAdapter.java
@@ -1,0 +1,28 @@
+package com.readysetgo.traveltracker.debtor.adapter.out;
+
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorJpaEntity;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorRepository;
+import com.readysetgo.traveltracker.debtor.application.port.out.LoadDebtorPort;
+import com.readysetgo.traveltracker.debtor.domain.Debtor;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 채무자 데이터를 조회하기 위한 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LoadDebtorAdapter implements LoadDebtorPort {
+
+    private final DebtorRepository debtorRepository;
+
+    @Override
+    public Debtor loadDebtor(Long debtorId) {
+        DebtorJpaEntity debtor = debtorRepository.findById(debtorId)
+            .orElseThrow(RuntimeException::new); // TODO: 적절한 커스텀 예외로 변경, 현재 500 발생
+
+        return Debtor.builder()
+            .id(debtor.getId())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/persistence/DebtorJpaEntity.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/persistence/DebtorJpaEntity.java
@@ -1,0 +1,25 @@
+package com.readysetgo.traveltracker.debtor.adapter.out.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 채무자 정보를 나타내는 JPA 엔터티 클래스입니다. 데이터베이스의 `DEBTOR` 테이블과 매핑됩니다.
+ */
+@Entity
+@Table(name = "DEBTOR")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PUBLIC) // TODO: 추후 필드 추가에 따른 JPA 요구사항에 따라 기본 생성자 제한
+public class DebtorJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 채무자 ID (Primary Key)
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/persistence/DebtorRepository.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/adapter/out/persistence/DebtorRepository.java
@@ -1,0 +1,10 @@
+package com.readysetgo.traveltracker.debtor.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 채무자 엔터티와 데이터베이스 간의 CRUD 작업을 수행하는 JPA 리포지토리 인터페이스입니다.
+ */
+public interface DebtorRepository extends JpaRepository<DebtorJpaEntity, Long> {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/CreateDebtorCommand.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/CreateDebtorCommand.java
@@ -1,0 +1,13 @@
+package com.readysetgo.traveltracker.debtor.application.port.in;
+
+import lombok.Builder;
+
+/**
+ * 채무자 생성 비즈니스 로직에 필요한 데이터를 전달하는 명령 객체입니다.
+ */
+@Builder
+public record CreateDebtorCommand(
+
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/CreateDebtorUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/CreateDebtorUseCase.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.debtor.application.port.in;
+
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.CreateDebtorResponse;
+
+/**
+ * 채무자 생성 유스케이스 인터페이스입니다.
+ */
+public interface CreateDebtorUseCase {
+
+    /**
+     * 채무자을 생성합니다.
+     *
+     * @param command 채무자 생성 명령 객체
+     * @return 생성된 채무자 정보
+     */
+    CreateDebtorResponse createDebtor(CreateDebtorCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/DeleteDebtorUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/DeleteDebtorUseCase.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.debtor.application.port.in;
+
+/**
+ * 채무자 삭제 유스케이스 인터페이스입니다.
+ */
+public interface DeleteDebtorUseCase {
+
+    /**
+     * 채무자을 삭제합니다.
+     *
+     * @param debtorId 삭제할 채무자 ID
+     * @return 삭제 성공 여부
+     */
+    boolean deleteDebtor(Long debtorId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/GetDebtorInfoQuery.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/port/in/GetDebtorInfoQuery.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.debtor.application.port.in;
+
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.GetDebtorInfoResponse;
+
+/**
+ * 채무자 조회 유스케이스 인터페이스입니다.
+ */
+public interface GetDebtorInfoQuery {
+
+    /**
+     * 채무자 정보를 조회합니다.
+     *
+     * @param debtorId 조회할 채무자 ID
+     * @return 채무자 정보 응답 객체
+     */
+    GetDebtorInfoResponse getDebtorInfo(Long debtorId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/port/out/CreateDebtorPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/port/out/CreateDebtorPort.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.debtor.application.port.out;
+
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorCommand;
+
+/**
+ * 채무자 생성 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface CreateDebtorPort {
+
+    /**
+     * 채무자을 생성합니다.
+     *
+     * @param command 채무자 생성 명령 객체
+     * @return 생성된 채무자 ID
+     */
+    Long createDebtor(CreateDebtorCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/port/out/DeleteDebtorPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/port/out/DeleteDebtorPort.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.debtor.application.port.out;
+
+/**
+ * 채무자 삭제 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface DeleteDebtorPort {
+
+    /**
+     * 채무자 데이터를 삭제합니다.
+     *
+     * @param debtorId 삭제할 채무자 ID
+     * @return 삭제 성공 여부
+     */
+    Boolean deleteDebtor(Long debtorId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/port/out/LoadDebtorPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/port/out/LoadDebtorPort.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.debtor.application.port.out;
+
+import com.readysetgo.traveltracker.debtor.domain.Debtor;
+
+/**
+ * 채무자 조회 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface LoadDebtorPort {
+
+    /**
+     * 채무자 데이터를 조회합니다.
+     *
+     * @param debtorId 조회할 채무자 ID
+     * @return 채무자 도메인 객체
+     */
+    Debtor loadDebtor(Long debtorId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/service/CreateDebtorService.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/service/CreateDebtorService.java
@@ -1,0 +1,27 @@
+package com.readysetgo.traveltracker.debtor.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.CreateDebtorResponse;
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorCommand;
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorUseCase;
+import com.readysetgo.traveltracker.debtor.application.port.out.CreateDebtorPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 채무자 생성 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateDebtorService implements CreateDebtorUseCase {
+
+    private final CreateDebtorPort createDebtorPort;
+
+    @Override
+    public CreateDebtorResponse createDebtor(CreateDebtorCommand command) {
+        return CreateDebtorResponse.builder()
+            .debtorId(createDebtorPort.createDebtor(command))
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/service/DeleteDebtorService.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/service/DeleteDebtorService.java
@@ -1,0 +1,23 @@
+package com.readysetgo.traveltracker.debtor.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.debtor.application.port.in.DeleteDebtorUseCase;
+import com.readysetgo.traveltracker.debtor.application.port.out.DeleteDebtorPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 채무자 삭제 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class DeleteDebtorService implements DeleteDebtorUseCase {
+
+    private final DeleteDebtorPort deleteDebtorPort;
+
+    @Override
+    public boolean deleteDebtor(Long debtorId) {
+        return deleteDebtorPort.deleteDebtor(debtorId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/application/service/GetDebtorInfoService.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/application/service/GetDebtorInfoService.java
@@ -1,0 +1,28 @@
+package com.readysetgo.traveltracker.debtor.application.service;
+
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.GetDebtorInfoResponse;
+import com.readysetgo.traveltracker.debtor.application.port.in.GetDebtorInfoQuery;
+import com.readysetgo.traveltracker.debtor.application.port.out.LoadDebtorPort;
+import com.readysetgo.traveltracker.debtor.domain.Debtor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 채무자 조회 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetDebtorInfoService implements GetDebtorInfoQuery {
+
+    private final LoadDebtorPort loadDebtorPort;
+
+    @Override
+    public GetDebtorInfoResponse getDebtorInfo(Long debtorId) {
+        Debtor debtor = loadDebtorPort.loadDebtor(debtorId);
+        return GetDebtorInfoResponse.builder()
+            .debtorId(debtor.getId())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/debtor/domain/Debtor.java
+++ b/src/main/java/com/readysetgo/traveltracker/debtor/domain/Debtor.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.debtor.domain;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+@Builder
+public class Debtor {
+
+    private Long id;
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
@@ -1,0 +1,66 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import com.readysetgo.traveltracker.common.helper.util.ArbitraryField;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.request.CreateDebtorRequest;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.CreateDebtorResponse;
+import com.readysetgo.traveltracker.debtor.adapter.in.web.response.GetDebtorInfoResponse;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorJpaEntity;
+
+/**
+ * API 테스트에서 사용되는 요청 및 응답 객체를 생성하는 헬퍼 클래스입니다.
+ * <p>
+ * 테스트 시 반복적으로 생성되는 객체를 미리 정의하여, 테스트의 간결성과 가독성을 높입니다.
+ * </p>
+ */
+public class ArbitraryFactory {
+
+    /**
+     * 채무자(Debtor) 관련 요청 및 응답 객체 생성을 위한 내부 클래스입니다.
+     */
+    public static class Debtor {
+
+        /**
+         * 미리 정의된 채무자 생성 요청 객체입니다.
+         * <p>
+         * 테스트에서 채무자 생성 요청 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final CreateDebtorRequest aCreateDebtorRequest =
+            CreateDebtorRequest.builder()
+                .build();
+
+        /**
+         * 미리 정의된 채무자 생성 응답 객체입니다.
+         * <p>
+         * 테스트에서 채무자 생성 결과 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final CreateDebtorResponse aCreateDebtorResponse =
+            CreateDebtorResponse.builder()
+                .debtorId(ArbitraryField.Debtor.DEBTOR_ID)
+                .build();
+
+        /**
+         * 미리 정의된 채무자 정보 조회 응답 객체입니다.
+         * <p>
+         * 테스트에서 채무자 조회 결과 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final GetDebtorInfoResponse aGetDebtorInfoResponse =
+            GetDebtorInfoResponse.builder()
+                .debtorId(ArbitraryField.Debtor.DEBTOR_ID)
+                .build();
+
+        /**
+         * 미리 정의된 `DebtorJpaEntity` 객체를 생성합니다.
+         * <p>
+         * 테스트에서 JPA 엔터티를 필요로 하는 경우에 활용됩니다.
+         * </p>
+         *
+         * @return 미리 정의된 `DebtorJpaEntity` 객체
+         */
+        public static DebtorJpaEntity aDebtorJpaEntity() {
+            return new DebtorJpaEntity();
+        }
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
@@ -1,0 +1,88 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Debtor;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NULL;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.ResultHandler;
+
+/**
+ * API 문서화를 위한 헬퍼 클래스입니다.
+ * <p>
+ * 각종 도메인 API의 요청 및 응답 필드를 문서화하여 Spring REST Docs를 통해 API 문서를 생성할 수 있도록 지원합니다.
+ * </p>
+ */
+public class DocsHelper {
+
+    public static class DebtorDocs {
+
+        /**
+         * 채무자 생성 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 채무자 생성 요청과 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 채무자 생성 API의 요청/응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler createDebtorDocumentation() {
+            return MockMvcRestDocumentation.document(Debtor.DOC_SECTION_CREATE_DEBTOR,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                ),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data.debtorId").type(NUMBER).description("생성된 채무자 ID"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 채무자 조회 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 채무자 조회 요청에 대한 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 채무자 조회 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler getDebtorDocumentation() {
+            return MockMvcRestDocumentation.document(Debtor.DOC_SECTION_GET_DEBTOR,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").description("응답 상태"),
+                    fieldWithPath("data.debtorId").description("채무자 ID"),
+                    fieldWithPath("error").description("오류 정보").optional()
+                )
+            );
+        }
+
+        /**
+         * 채무자 삭제 API 문서화를 위한 메서드입니다.
+         * <p>
+         * 채무자 삭제 요청에 대한 응답 필드를 정의하여 문서화에 활용합니다.
+         * </p>
+         *
+         * @return 채무자 삭제 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler deleteDebtorDocumentation() {
+            return MockMvcRestDocumentation.document(Debtor.DOC_SECTION_DELETE_DEBTOR,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data").type(BOOLEAN).description("삭제 성공 여부"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
@@ -1,0 +1,51 @@
+package com.readysetgo.traveltracker.common.helper.util;
+
+/**
+ * API 테스트에서 사용되는 임의의 필드 값을 정의한 클래스입니다.
+ * <p>
+ * 각종 도메인 관련 요청 및 응답 필드 값, URL, 문서화 섹션명을 포함하고 있어 테스트 및 문서화 설정 시 활용됩니다.
+ * </p>
+ */
+public class ArbitraryField {
+
+    /**
+     * 채무자(Debtor) 관련 임의의 필드 값과 URL을 정의한 내부 클래스입니다.
+     */
+    public static class Debtor {
+
+        /**
+         * 임의의 채무자 ID
+         */
+        public static final Long ID = 56L;
+
+        /**
+         * 채무자 API의 기본 URL
+         */
+        public static final String DEBTOR_BASE_URL = "/v1/debtors";
+
+        /**
+         * 채무자 ID를 포함한 상세 조회 URL
+         */
+        public static final String DEBTOR_ID_URL = DEBTOR_BASE_URL + "/{id}";
+
+        /**
+         * 채무자 생성 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_CREATE_DEBTOR = "create-debtor";
+
+        /**
+         * 채무자 조회 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_GET_DEBTOR = "get-debtor";
+
+        /**
+         * 채무자 삭제 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_DELETE_DEBTOR = "delete-debtor";
+
+        /**
+         * 임의의 채무자 ID (특정 테스트용)
+         */
+        public static final Long DEBTOR_ID = 90L;
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/debtor/adapter/LoadExpenseAdapterTest.java
+++ b/src/test/java/com/readysetgo/traveltracker/debtor/adapter/LoadExpenseAdapterTest.java
@@ -1,0 +1,59 @@
+package com.readysetgo.traveltracker.debtor.adapter;
+
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Debtor.aDebtorJpaEntity;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.readysetgo.traveltracker.debtor.adapter.out.LoadDebtorAdapter;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorJpaEntity;
+import com.readysetgo.traveltracker.debtor.adapter.out.persistence.DebtorRepository;
+import com.readysetgo.traveltracker.debtor.domain.Debtor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * {@link LoadDebtorAdapter}에 대한 통합 테스트 클래스입니다.
+ * <p>
+ * 이 클래스는 데이터베이스와의 실제 상호작용을 통해 어댑터의 동작을 검증합니다.
+ * </p>
+ */
+@SpringBootTest
+class LoadDebtorAdapterTest {
+
+    @Autowired
+    private LoadDebtorAdapter loadDebtorAdapter;
+
+    @Autowired
+    private DebtorRepository debtorRepository;
+
+    /**
+     * 각 테스트 후 데이터 정리를 수행합니다.
+     */
+    @AfterEach
+    void tearDown() {
+        debtorRepository.deleteAllInBatch(); // 데이터 정리
+    }
+
+    /**
+     * 어댑터를 사용하여 데이터베이스에서 채무자 정보를 불러오는 테스트입니다.
+     */
+    @DisplayName("데이터베이스에 저장된 채무자을 어댑터로 불러올 때 유효한 채무자 반환")
+    @Test
+    void debtorSavedInDatabase_loadedThroughAdapter_returnsValidDebtor() {
+        // given
+        DebtorJpaEntity debtorEntity = aDebtorJpaEntity();
+        debtorRepository.save(debtorEntity);
+
+        // when
+        Debtor debtor = loadDebtorAdapter.loadDebtor(debtorEntity.getId());
+
+        // then
+        assertThat(debtor, is(notNullValue())); // 객체가 null이 아님을 확인
+        assertThat(debtor.getId(), is(equalTo(debtorEntity.getId())));
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/docs/DebtorControllerDocsTest.java
+++ b/src/test/java/com/readysetgo/traveltracker/docs/DebtorControllerDocsTest.java
@@ -1,0 +1,128 @@
+package com.readysetgo.traveltracker.docs;
+
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Debtor.aCreateDebtorRequest;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Debtor.aCreateDebtorResponse;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Debtor.aGetDebtorInfoResponse;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.DebtorDocs.createDebtorDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.DebtorDocs.deleteDebtorDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.DebtorDocs.getDebtorDocumentation;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Debtor.DEBTOR_BASE_URL;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Debtor.DEBTOR_ID_URL;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Debtor.ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorCommand;
+import com.readysetgo.traveltracker.debtor.application.port.in.CreateDebtorUseCase;
+import com.readysetgo.traveltracker.debtor.application.port.in.DeleteDebtorUseCase;
+import com.readysetgo.traveltracker.debtor.application.port.in.GetDebtorInfoQuery;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+/**
+ * 채무자 API에 대한 REST Docs 테스트 클래스입니다.
+ * <p>
+ * 채무자 생성, 조회, 수정, 삭제 요청의 API 문서화를 위해 MockMVC와 REST Docs를 이용해 요청 및 응답 필드를 문서화하고 예제 테스트 케이스를 제공합니다.
+ * </p>
+ */
+@DisplayName("채무자 API 문서 생성 테스트")
+public class DebtorControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private CreateDebtorUseCase createDebtorUseCase;
+
+    @MockBean
+    private GetDebtorInfoQuery getDebtorInfoQuery;
+
+    @MockBean
+    private DeleteDebtorUseCase deleteDebtorUseCase;
+
+    /**
+     * 채무자 생성 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("채무자 생성 요청")
+    class CreateDebtor {
+
+        /**
+         * 유효한 채무자 생성 요청 시 성공적으로 채무자가 생성되고, API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("채무자 생성 성공")
+        void validDebtorRequest_createsDebtor_returnsCreatedStatus() throws Exception {
+            given(createDebtorUseCase.createDebtor(any(CreateDebtorCommand.class)))
+                .willReturn(aCreateDebtorResponse);
+
+            String body = objectMapper.writeValueAsString(aCreateDebtorRequest);
+
+            ResultActions perform = mockMvc.perform(post(DEBTOR_BASE_URL)
+                .contentType(APPLICATION_JSON)
+                .content(body));
+            perform
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 201로 수정 필요
+                .andDo(createDebtorDocumentation());
+        }
+    }
+
+    /**
+     * 채무자 조회 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("채무자 조회 요청")
+    class GetDebtorInfo {
+
+        /**
+         * 존재하는 채무자 ID로 요청 시, 채무자 정보를 성공적으로 조회하고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("채무자 조회 성공")
+        void existingDebtorId_retrievesDebtor_returnsDebtorDetails() throws Exception {
+            given(getDebtorInfoQuery.getDebtorInfo(anyLong()))
+                .willReturn(aGetDebtorInfoResponse);
+
+            mockMvc.perform(get(DEBTOR_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(getDebtorDocumentation());
+        }
+    }
+
+    /**
+     * 채무자 삭제 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("채무자 삭제 요청")
+    class DeleteDebtor {
+
+        /**
+         * 존재하는 채무자 ID로 삭제 요청 시, 성공적으로 채무자가 삭제되고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("채무자 삭제 성공")
+        void existingDebtorId_deletesDebtor_returnsNoContentStatus() throws Exception {
+            given(deleteDebtorUseCase.deleteDebtor(anyLong())).willReturn(true);
+
+            mockMvc.perform(delete(DEBTOR_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 204로 수정 필요
+                .andDo(deleteDebtorDocumentation());
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #22

## 📌 PR 요약

채무자(Debtor) 도메인 정의  
타 도메인 연관관계를 제외한 CRD 기능 구현  
관련 API 문서 작성

## 🔍 주요 변경 사항

- **채무자 도메인 정의**
  - `Debtor` 클래스 추가: `id` 필드 정의
- **채무자 JPA 설정 추가**
  - 채무자 엔티티 및 리포지토리 정의
  - DB 매핑 및 기본 쿼리 기능 제공
- **채무자 CRD 기능 구현**
  - **Create**: 채무자 생성 API 및 저장 로직 구현
    - 요청 및 응답 데이터를 위한 DTO 클래스 추가
  - **Read**: 채무자 조회 API 및 데이터 로드 어댑터 구현
    - 응답 데이터를 위한 DTO 클래스 추가
  - **Delete**: 채무자 삭제 API 및 요청 처리 로직 구현
- **채무자 테스트 추가**
  - CRD 기능별 API 테스트 작성
  - 테스트 데이터 생성을 위한 헬퍼 클래스 추가
  - 어댑터 동작 검증 테스트 작성
- **채무자 API 문서화**
  - REST Docs를 활용하여 요청/응답 스펙 정의
  - 컨트롤러별 문서화 테스트 클래스 작성

## 🧪 테스트 방법
```
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- 기능 특성상 Update에 대한 기능을 필요시 추가 예정입니다.
- 응답 관련 수정 `TODO` 내용은 추후 요구사항에 적용할 예정입니다.
- 테스트 코드의 예외 및 BeanValidation 관련 필드 검증내용은 추후 추가 예정입니다.
- 타 도메인 연관관계는 추후 추가 예정입니다 