### PR TITLE
[FEAT] #15 카테고리 기본 CRD 구현

### DIFF
--- a/src/docs/asciidoc/api/category/create-category.adoc
+++ b/src/docs/asciidoc/api/category/create-category.adoc
@@ -1,0 +1,12 @@
+[[create-category]]
+=== 카테고리 생성
+
+==== HTTP Request
+
+include::{snippets}/create-category/http-request.adoc[]
+include::{snippets}/create-category/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/create-category/http-response.adoc[]
+include::{snippets}/create-category/response-fields.adoc[]

--- a/src/docs/asciidoc/api/category/delete-category.adoc
+++ b/src/docs/asciidoc/api/category/delete-category.adoc
@@ -1,0 +1,11 @@
+[[delete-category]]
+=== 카테고리 삭제
+
+==== HTTP Request
+
+include::{snippets}/delete-category/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/delete-category/http-response.adoc[]
+include::{snippets}/delete-category/response-fields.adoc[]

--- a/src/docs/asciidoc/api/category/get-category-info.adoc
+++ b/src/docs/asciidoc/api/category/get-category-info.adoc
@@ -1,0 +1,11 @@
+[[get-category]]
+=== 카테고리 정보 조회
+
+==== HTTP Request
+
+include::{snippets}/get-category/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/get-category/http-response.adoc[]
+include::{snippets}/get-category/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,3 +16,10 @@ include::api/group/create-group.adoc[]
 include::api/group/get-group-info.adoc[]
 include::api/group/update-group.adoc[]
 include::api/group/delete-group.adoc[]
+
+[[category-API]]
+== Category API
+
+include::api/category/create-category.adoc[]
+include::api/category/get-category-info.adoc[]
+include::api/category/delete-category.adoc[]

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/CreateCategoryController.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/CreateCategoryController.java
@@ -1,0 +1,35 @@
+package com.readysetgo.traveltracker.category.adapter.in.web;
+
+import com.readysetgo.traveltracker.category.adapter.in.web.request.CreateCategoryRequest;
+import com.readysetgo.traveltracker.category.adapter.in.web.response.CreateCategoryResponse;
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryCommand;
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryUseCase;
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 카테고리 생성 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class CreateCategoryController {
+
+    private final CreateCategoryUseCase createCategoryUseCase;
+
+    /**
+     * 카테고리를 생성합니다.
+     *
+     * @param request 카테고리 생성 요청 데이터
+     * @return 생성된 카테고리 정보
+     */
+    @PostMapping("/v1/categories")
+    public CreateCategoryResponse createCategory(@RequestBody CreateCategoryRequest request) {
+        return createCategoryUseCase.createCategory(CreateCategoryCommand.builder()
+            .name(request.name())
+            .build());
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/DeleteCategoryController.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/DeleteCategoryController.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.category.adapter.in.web;
+
+import com.readysetgo.traveltracker.category.application.port.in.DeleteCategoryUseCase;
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 카테고리 삭제 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class DeleteCategoryController {
+
+    private final DeleteCategoryUseCase deleteCategoryUseCase;
+
+    /**
+     * 카테고리를 삭제합니다.
+     *
+     * @param categoryId 삭제할 카테고리 ID
+     * @return 삭제 성공 여부
+     */
+    @DeleteMapping("/v1/categories/{categoryId}")
+    public Boolean deleteCategory(@PathVariable Long categoryId) {
+        return deleteCategoryUseCase.deleteCategory(categoryId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/GetCategoryInfoController.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/GetCategoryInfoController.java
@@ -1,0 +1,31 @@
+package com.readysetgo.traveltracker.category.adapter.in.web;
+
+import com.readysetgo.traveltracker.category.adapter.in.web.response.GetCategoryInfoResponse;
+import com.readysetgo.traveltracker.category.application.port.in.GetCategoryInfoQuery;
+import com.readysetgo.traveltracker.common.annotation.WebAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 카테고리 조회 요청을 처리하는 컨트롤러 클래스입니다.
+ */
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class GetCategoryInfoController {
+
+    private final GetCategoryInfoQuery getCategoryInfoQuery;
+
+    /**
+     * 카테고리를 조회합니다.
+     *
+     * @param categoryId 조회할 카테고리 ID
+     * @return 카테고리 정보
+     */
+    @GetMapping("/v1/categories/{categoryId}")
+    public GetCategoryInfoResponse getCategoryInfo(@PathVariable Long categoryId) {
+        return getCategoryInfoQuery.getCategoryInfo(categoryId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/request/CreateCategoryRequest.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/request/CreateCategoryRequest.java
@@ -1,0 +1,13 @@
+package com.readysetgo.traveltracker.category.adapter.in.web.request;
+
+import lombok.Builder;
+
+/**
+ * 카테고리 생성 요청 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record CreateCategoryRequest(
+    String name // 카테고리 이름
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/response/CreateCategoryResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/response/CreateCategoryResponse.java
@@ -1,0 +1,13 @@
+package com.readysetgo.traveltracker.category.adapter.in.web.response;
+
+import lombok.Builder;
+
+/**
+ * 카테고리 생성 응답 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record CreateCategoryResponse(
+    Long categoryId // 생성된 카테고리 ID
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/response/GetCategoryInfoResponse.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/in/web/response/GetCategoryInfoResponse.java
@@ -1,0 +1,14 @@
+package com.readysetgo.traveltracker.category.adapter.in.web.response;
+
+import lombok.Builder;
+
+/**
+ * 카테고리 조회 응답 데이터를 표현하는 DTO 클래스입니다.
+ */
+@Builder
+public record GetCategoryInfoResponse(
+    Long categoryId, // 카테고리 ID
+    String name      // 카테고리 이름
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/out/CreateCategoryAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/out/CreateCategoryAdapter.java
@@ -1,0 +1,31 @@
+package com.readysetgo.traveltracker.category.adapter.out;
+
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryJpaEntity;
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryRepository;
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryCommand;
+import com.readysetgo.traveltracker.category.application.port.out.CreateCategoryPort;
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 카테고리 데이터를 영속성 계층에 저장하는 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class CreateCategoryAdapter implements CreateCategoryPort {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Long createCategory(CreateCategoryCommand command) {
+        CategoryJpaEntity category = createCategoryEntity(command);
+        categoryRepository.save(category);
+        return category.getId();
+    }
+
+    private CategoryJpaEntity createCategoryEntity(CreateCategoryCommand command) {
+        return CategoryJpaEntity.builder()
+            .name(command.name())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/out/DeleteCategoryAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/out/DeleteCategoryAdapter.java
@@ -1,0 +1,23 @@
+package com.readysetgo.traveltracker.category.adapter.out;
+
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryRepository;
+import com.readysetgo.traveltracker.category.application.port.out.DeleteCategoryPort;
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 카테고리를 삭제하기 위한 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class DeleteCategoryAdapter implements DeleteCategoryPort {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Boolean deleteCategory(Long categoryId) {
+        categoryRepository.deleteById(categoryId);
+
+        return true; //TODO: 필요시 요청에 따른 응답으로 변경
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/out/LoadCategoryAdapter.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/out/LoadCategoryAdapter.java
@@ -1,0 +1,29 @@
+package com.readysetgo.traveltracker.category.adapter.out;
+
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryJpaEntity;
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryRepository;
+import com.readysetgo.traveltracker.category.application.port.out.LoadCategoryPort;
+import com.readysetgo.traveltracker.category.domain.Category;
+import com.readysetgo.traveltracker.common.annotation.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 카테고리 데이터를 조회하기 위한 어댑터 클래스입니다.
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LoadCategoryAdapter implements LoadCategoryPort {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Category loadCategory(Long categoryId) {
+        CategoryJpaEntity category = categoryRepository.findById(categoryId)
+            .orElseThrow(RuntimeException::new); // TODO: 적절한 예외 처리 추가 현재 500 응답
+
+        return Category.builder()
+            .id(categoryId)
+            .name(category.getName())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/out/persistence/CategoryJpaEntity.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/out/persistence/CategoryJpaEntity.java
@@ -1,0 +1,40 @@
+package com.readysetgo.traveltracker.category.adapter.out.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카테고리 정보를 나타내는 JPA 엔터티 클래스입니다.
+ * <p>
+ * 데이터베이스의 `CATEGORY` 테이블과 매핑됩니다.
+ * </p>
+ */
+@Entity
+@Table(name = "CATEGORY")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 요구사항에 따라 기본 생성자 제한
+public class CategoryJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 카테고리 ID (Primary Key)
+
+    private String name; // 카테고리 이름
+
+    /**
+     * 카테고리 엔터티 생성자.
+     *
+     * @param name 카테고리 이름
+     */
+    @Builder
+    private CategoryJpaEntity(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/adapter/out/persistence/CategoryRepository.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/adapter/out/persistence/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.readysetgo.traveltracker.category.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 카테고리 엔터티와 데이터베이스 간의 CRUD 작업을 수행하는 JPA 리포지토리 인터페이스입니다.
+ */
+public interface CategoryRepository extends JpaRepository<CategoryJpaEntity, Long> {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/port/in/CreateCategoryCommand.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/port/in/CreateCategoryCommand.java
@@ -1,0 +1,14 @@
+package com.readysetgo.traveltracker.category.application.port.in;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+
+/**
+ * 카테고리 생성 비즈니스 로직에 필요한 데이터를 전달하는 명령 객체입니다.
+ */
+@Builder
+public record CreateCategoryCommand(
+    @NotEmpty String name // 카테고리 이름
+) {
+
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/port/in/CreateCategoryUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/port/in/CreateCategoryUseCase.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.category.application.port.in;
+
+import com.readysetgo.traveltracker.category.adapter.in.web.response.CreateCategoryResponse;
+
+/**
+ * 카테고리 생성 유스케이스 인터페이스입니다.
+ */
+public interface CreateCategoryUseCase {
+
+    /**
+     * 카테고리를 생성합니다.
+     *
+     * @param command 카테고리 생성 명령 객체
+     * @return 생성된 카테고리 정보
+     */
+    CreateCategoryResponse createCategory(CreateCategoryCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/port/in/DeleteCategoryUseCase.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/port/in/DeleteCategoryUseCase.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.category.application.port.in;
+
+/**
+ * 카테고리 삭제 유스케이스 인터페이스입니다.
+ */
+public interface DeleteCategoryUseCase {
+
+    /**
+     * 카테고리를 삭제합니다.
+     *
+     * @param categoryId 삭제할 카테고리 ID
+     * @return 삭제 성공 여부
+     */
+    boolean deleteCategory(Long categoryId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/port/in/GetCategoryInfoQuery.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/port/in/GetCategoryInfoQuery.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.category.application.port.in;
+
+import com.readysetgo.traveltracker.category.adapter.in.web.response.GetCategoryInfoResponse;
+
+/**
+ * 카테고리 조회 유스케이스 인터페이스입니다.
+ */
+public interface GetCategoryInfoQuery {
+
+    /**
+     * 카테고리 정보를 조회합니다.
+     *
+     * @param categoryId 조회할 카테고리 ID
+     * @return 카테고리 정보 응답 객체
+     */
+    GetCategoryInfoResponse getCategoryInfo(Long categoryId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/port/out/CreateCategoryPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/port/out/CreateCategoryPort.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.category.application.port.out;
+
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryCommand;
+
+/**
+ * 카테고리 생성 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface CreateCategoryPort {
+
+    /**
+     * 카테고리를 생성합니다.
+     *
+     * @param command 카테고리 생성 명령 객체
+     * @return 생성된 카테고리 ID
+     */
+    Long createCategory(CreateCategoryCommand command);
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/port/out/DeleteCategoryPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/port/out/DeleteCategoryPort.java
@@ -1,0 +1,15 @@
+package com.readysetgo.traveltracker.category.application.port.out;
+
+/**
+ * 카테고리 삭제 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface DeleteCategoryPort {
+
+    /**
+     * 카테고리를 삭제합니다.
+     *
+     * @param categoryId 삭제할 카테고리 ID
+     * @return 삭제 성공 여부
+     */
+    Boolean deleteCategory(Long categoryId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/port/out/LoadCategoryPort.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/port/out/LoadCategoryPort.java
@@ -1,0 +1,17 @@
+package com.readysetgo.traveltracker.category.application.port.out;
+
+import com.readysetgo.traveltracker.category.domain.Category;
+
+/**
+ * 카테고리 조회 작업을 영속성 계층에 위임하기 위한 포트 인터페이스입니다.
+ */
+public interface LoadCategoryPort {
+
+    /**
+     * 카테고리 데이터를 조회합니다.
+     *
+     * @param categoryId 조회할 카테고리 ID
+     * @return 카테고리 도메인 객체
+     */
+    Category loadCategory(Long categoryId);
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/service/CreateCategoryService.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/service/CreateCategoryService.java
@@ -1,0 +1,25 @@
+package com.readysetgo.traveltracker.category.application.service;
+
+import com.readysetgo.traveltracker.category.adapter.in.web.response.CreateCategoryResponse;
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryCommand;
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryUseCase;
+import com.readysetgo.traveltracker.category.application.port.out.CreateCategoryPort;
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 카테고리 생성 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateCategoryService implements CreateCategoryUseCase {
+
+    private final CreateCategoryPort createCategoryPort;
+
+    @Override
+    public CreateCategoryResponse createCategory(CreateCategoryCommand command) {
+        return new CreateCategoryResponse(createCategoryPort.createCategory(command));
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/service/DeleteCategoryService.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/service/DeleteCategoryService.java
@@ -1,0 +1,23 @@
+package com.readysetgo.traveltracker.category.application.service;
+
+import com.readysetgo.traveltracker.category.application.port.in.DeleteCategoryUseCase;
+import com.readysetgo.traveltracker.category.application.port.out.DeleteCategoryPort;
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 카테고리 삭제 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class DeleteCategoryService implements DeleteCategoryUseCase {
+
+    private final DeleteCategoryPort deleteCategoryPort;
+
+    @Override
+    public boolean deleteCategory(Long categoryId) {
+        return deleteCategoryPort.deleteCategory(categoryId);
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/application/service/GetCategoryInfoService.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/application/service/GetCategoryInfoService.java
@@ -1,0 +1,30 @@
+package com.readysetgo.traveltracker.category.application.service;
+
+import com.readysetgo.traveltracker.category.adapter.in.web.response.GetCategoryInfoResponse;
+import com.readysetgo.traveltracker.category.application.port.in.GetCategoryInfoQuery;
+import com.readysetgo.traveltracker.category.application.port.out.LoadCategoryPort;
+import com.readysetgo.traveltracker.category.domain.Category;
+import com.readysetgo.traveltracker.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 카테고리 조회 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetCategoryInfoService implements GetCategoryInfoQuery {
+
+    private final LoadCategoryPort loadCategoryPort;
+
+    @Override
+    public GetCategoryInfoResponse getCategoryInfo(Long categoryId) {
+        Category category = loadCategoryPort.loadCategory(categoryId);
+
+        return GetCategoryInfoResponse.builder()
+            .categoryId(category.getId())
+            .name(category.getName())
+            .build();
+    }
+}

--- a/src/main/java/com/readysetgo/traveltracker/category/domain/Category.java
+++ b/src/main/java/com/readysetgo/traveltracker/category/domain/Category.java
@@ -1,0 +1,29 @@
+package com.readysetgo.traveltracker.category.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 카테고리를 나타내는 도메인 클래스입니다.
+ * <p>
+ * 비즈니스 로직과 밀접하게 연관된 데이터를 표현하며, 데이터베이스 엔터티와 분리된 형태로 사용됩니다.
+ * </p>
+ */
+@Getter
+public class Category {
+
+    private final String name; // 카테고리 이름
+    private Long id;           // 카테고리 ID
+
+    /**
+     * 카테고리 객체 생성자.
+     *
+     * @param name 카테고리 이름
+     * @param id   카테고리 ID
+     */
+    @Builder
+    private Category(String name, Long id) {
+        this.name = name;
+        this.id = id;
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/category/adapter/LoadDebtorAdapterTest.java
+++ b/src/test/java/com/readysetgo/traveltracker/category/adapter/LoadDebtorAdapterTest.java
@@ -1,0 +1,59 @@
+package com.readysetgo.traveltracker.category.adapter;
+
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Category.aCategoryJpaEntity;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.readysetgo.traveltracker.category.adapter.out.LoadCategoryAdapter;
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryJpaEntity;
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryRepository;
+import com.readysetgo.traveltracker.category.domain.Category;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * {@link LoadCategoryAdapter}에 대한 통합 테스트 클래스입니다.
+ * <p>
+ * 이 클래스는 데이터베이스와의 실제 상호작용을 통해 어댑터의 동작을 검증합니다.
+ * </p>
+ */
+@SpringBootTest
+class LoadCategoryAdapterTest {
+
+    @Autowired
+    private LoadCategoryAdapter loadCategoryAdapter;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    /**
+     * 각 테스트 후 데이터 정리를 수행합니다.
+     */
+    @AfterEach
+    void tearDown() {
+        categoryRepository.deleteAllInBatch(); // 데이터 정리
+    }
+
+    /**
+     * 어댑터를 사용하여 데이터베이스에서 카테고리 정보를 불러오는 테스트입니다.
+     */
+    @DisplayName("데이터베이스에 저장된 카테고리을 어댑터로 불러올 때 유효한 카테고리 반환")
+    @Test
+    void categorySavedInDatabase_loadedThroughAdapter_returnsValidCategory() {
+        // given
+        CategoryJpaEntity categoryEntity = aCategoryJpaEntity();
+        categoryRepository.save(categoryEntity);
+
+        // when
+        Category category = loadCategoryAdapter.loadCategory(categoryEntity.getId());
+
+        // then
+        assertThat(category, is(notNullValue())); // 객체가 null이 아님을 확인
+        assertThat(category.getId(), is(equalTo(categoryEntity.getId())));
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/ArbitraryFactory.java
@@ -1,0 +1,72 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Category.ID;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Category.NAME;
+
+import com.readysetgo.traveltracker.category.adapter.in.web.request.CreateCategoryRequest;
+import com.readysetgo.traveltracker.category.adapter.in.web.response.CreateCategoryResponse;
+import com.readysetgo.traveltracker.category.adapter.in.web.response.GetCategoryInfoResponse;
+import com.readysetgo.traveltracker.category.adapter.out.persistence.CategoryJpaEntity;
+
+/**
+ * API 테스트에서 사용되는 요청 및 응답 객체를 생성하는 헬퍼 클래스입니다.
+ * <p>
+ * 테스트 시 반복적으로 생성되는 객체를 미리 정의하여, 테스트의 간결성과 가독성을 높입니다.
+ * </p>
+ */
+public class ArbitraryFactory {
+
+    /**
+     * 카테고리 관련 요청 및 응답 객체 생성을 위한 내부 클래스입니다.
+     */
+    public static class Category {
+
+        /**
+         * 미리 정의된 카테고리 생성 요청 객체입니다.
+         * <p>
+         * 테스트에서 카테고리 생성 요청 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final CreateCategoryRequest aCreateCategoryRequest =
+            CreateCategoryRequest.builder()
+                .name(NAME)
+                .build();
+
+        /**
+         * 미리 정의된 카테고리 생성 응답 객체입니다.
+         * <p>
+         * 테스트에서 카테고리 생성 결과 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final CreateCategoryResponse aCreateCategoryResponse =
+            CreateCategoryResponse.builder()
+                .categoryId(ID)
+                .build();
+
+        /**
+         * 미리 정의된 카테고리 정보 조회 응답 객체입니다.
+         * <p>
+         * 테스트에서 카테고리 조회 결과 데이터를 반복적으로 사용할 때 활용됩니다.
+         * </p>
+         */
+        public static final GetCategoryInfoResponse aGetCategoryInfoResponse =
+            GetCategoryInfoResponse.builder()
+                .categoryId(ID)
+                .name(NAME)
+                .build();
+
+        /**
+         * 미리 정의된 `CategoryJpaEntity` 객체를 생성합니다.
+         * <p>
+         * 테스트에서 JPA 엔터티를 필요로 하는 경우에 활용됩니다.
+         * </p>
+         *
+         * @return 미리 정의된 `CategoryJpaEntity` 객체
+         */
+        public static CategoryJpaEntity aCategoryJpaEntity() {
+            return CategoryJpaEntity.builder()
+                .name(NAME)
+                .build();
+        }
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/DocsHelper.java
@@ -1,0 +1,84 @@
+package com.readysetgo.traveltracker.common.helper;
+
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Category;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NULL;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.ResultHandler;
+
+/**
+ * API 문서화를 위한 헬퍼 클래스입니다.
+ * <p>
+ * 각종 도메인 API의 요청 및 응답 필드를 문서화하여 Spring REST Docs를 통해 API 문서를 생성할 수 있도록 지원합니다.
+ * </p>
+ */
+public class DocsHelper {
+
+    /**
+     * 카테고리 관련 API 문서화를 위한 내부 클래스입니다.
+     */
+    public static class CategoryDocs {
+
+        /**
+         * 카테고리 생성 API 문서화를 위한 메서드입니다.
+         *
+         * @return 카테고리 생성 API의 요청/응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler createCategoryDocumentation() {
+            return MockMvcRestDocumentation.document(Category.DOC_SECTION_CREATE,
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("name").type(STRING).description("카테고리 이름")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data.categoryId").type(NUMBER).description("생성된 카테고리 ID"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 카테고리 조회 API 문서화를 위한 메서드입니다.
+         *
+         * @return 카테고리 조회 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler getCategoryDocumentation() {
+            return MockMvcRestDocumentation.document(Category.DOC_SECTION_GET,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data.categoryId").type(NUMBER).description("카테고리 ID"),
+                    fieldWithPath("data.name").type(STRING).description("카테고리 이름"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+
+        /**
+         * 카테고리 삭제 API 문서화를 위한 메서드입니다.
+         *
+         * @return 카테고리 삭제 API의 응답 문서화 설정이 적용된 {@link ResultHandler}
+         */
+        public static ResultHandler deleteCategoryDocumentation() {
+            return MockMvcRestDocumentation.document(Category.DOC_SECTION_DELETE,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("status").type(STRING).description("API 성공 여부"),
+                    fieldWithPath("data").type(BOOLEAN).description("삭제 성공 여부"),
+                    fieldWithPath("error").type(NULL).description("에러 정보")
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
+++ b/src/test/java/com/readysetgo/traveltracker/common/helper/util/ArbitraryField.java
@@ -1,0 +1,45 @@
+package com.readysetgo.traveltracker.common.helper.util;
+
+/**
+ * API 테스트에서 사용되는 임의의 필드 값을 정의한 클래스입니다.
+ * <p>
+ * 각종 도메인 관련 요청 및 응답 필드 값, URL, 문서화 섹션명을 포함하고 있어 테스트 및 문서화 설정 시 활용됩니다.
+ * </p>
+ */
+public class ArbitraryField {
+
+    /**
+     * 카테고리 관련 임의의 필드 값과 URL을 정의한 내부 클래스입니다.
+     */
+    public static class Category {
+
+        /**
+         * 카테고리 생성 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_CREATE = "create-category";
+        /**
+         * 카테고리 조회 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_GET = "get-category";
+        /**
+         * 카테고리 삭제 API 문서화 섹션 이름
+         */
+        public static final String DOC_SECTION_DELETE = "delete-category";
+        /**
+         * 카테고리 API의 기본 URL
+         */
+        public static final String CATEGORY_BASE_URL = "/v1/categories";
+        /**
+         * 카테고리 ID를 포함한 상세 조회 URL
+         */
+        public static final String CATEGORY_ID_URL = CATEGORY_BASE_URL + "/{id}";
+        /**
+         * 임의의 카테고리 ID
+         */
+        public static final Long ID = 34L;
+        /**
+         * 임의의 카테고리 이름
+         */
+        public static final String NAME = "Arbitrary Category";
+    }
+}

--- a/src/test/java/com/readysetgo/traveltracker/docs/CategoryControllerDocsTest.java
+++ b/src/test/java/com/readysetgo/traveltracker/docs/CategoryControllerDocsTest.java
@@ -1,0 +1,137 @@
+package com.readysetgo.traveltracker.docs;
+
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Category.aCreateCategoryRequest;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Category.aCreateCategoryResponse;
+import static com.readysetgo.traveltracker.common.helper.ArbitraryFactory.Category.aGetCategoryInfoResponse;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.CategoryDocs.createCategoryDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.CategoryDocs.deleteCategoryDocumentation;
+import static com.readysetgo.traveltracker.common.helper.DocsHelper.CategoryDocs.getCategoryDocumentation;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Category.CATEGORY_BASE_URL;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Category.CATEGORY_ID_URL;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Category.ID;
+import static com.readysetgo.traveltracker.common.helper.util.ArbitraryField.Category.NAME;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryCommand;
+import com.readysetgo.traveltracker.category.application.port.in.CreateCategoryUseCase;
+import com.readysetgo.traveltracker.category.application.port.in.DeleteCategoryUseCase;
+import com.readysetgo.traveltracker.category.application.port.in.GetCategoryInfoQuery;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+/**
+ * 카테고리 API에 대한 REST Docs 테스트 클래스입니다.
+ * <p>
+ * 카테고리 생성, 조회, 수정, 삭제 요청의 API 문서화를 위해 MockMVC와 REST Docs를 이용해 요청 및 응답 필드를 문서화하고 예제 테스트 케이스를 제공합니다.
+ * </p>
+ */
+@DisplayName("카테고리 API 문서 생성 테스트")
+public class CategoryControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private CreateCategoryUseCase createCategoryUseCase;
+
+    @MockBean
+    private GetCategoryInfoQuery getCategoryInfoQuery;
+
+    @MockBean
+    private DeleteCategoryUseCase deleteCategoryUseCase;
+
+    /**
+     * 카테고리 생성 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("카테고리 생성 요청")
+    class CreateCategory {
+
+        /**
+         * 유효한 카테고리 생성 요청 시 성공적으로 카테고리가 생성되고, API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("카테고리 생성 성공")
+        void validCategoryRequest_createsCategory_returnsCreatedStatus() throws Exception {
+            // given
+            given(createCategoryUseCase.createCategory(any(CreateCategoryCommand.class)))
+                .willReturn(aCreateCategoryResponse);
+
+            String body = objectMapper.writeValueAsString(aCreateCategoryRequest);
+
+            // when, then
+            mockMvc.perform(post(CATEGORY_BASE_URL)
+                    .contentType(APPLICATION_JSON)
+                    .content(body))
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 201 로 수정 필요
+                .andDo(createCategoryDocumentation());
+        }
+    }
+
+    /**
+     * 카테고리 조회 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("카테고리 조회 요청")
+    class GetCategoryInfo {
+
+        /**
+         * 존재하는 카테고리 ID로 요청 시, 카테고리 정보를 성공적으로 조회하고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("카테고리 조회 성공")
+        void existingCategoryId_retrievesCategory_returnsCategoryDetails() throws Exception {
+            // given
+            given(getCategoryInfoQuery.getCategoryInfo(anyLong()))
+                .willReturn(aGetCategoryInfoResponse);
+
+            // when, then
+            mockMvc.perform(get(CATEGORY_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.categoryId").value(ID))
+                .andExpect(jsonPath("$.data.name").value(NAME))
+                .andDo(getCategoryDocumentation());
+        }
+    }
+
+
+    /**
+     * 카테고리 삭제 요청에 대한 API 문서화 테스트 클래스입니다.
+     */
+    @Nested
+    @DisplayName("카테고리 삭제 요청")
+    class DeleteCategory {
+
+        /**
+         * 존재하는 카테고리 ID로 삭제 요청 시, 성공적으로 카테고리가 삭제되고 API 문서화가 수행됩니다.
+         *
+         * @throws Exception MockMVC 요청 수행 시 발생할 수 있는 예외
+         */
+        @Test
+        @DisplayName("카테고리 삭제 성공")
+        void existingCategoryId_deletesCategory_returnsNoContentStatus() throws Exception {
+            // given
+            given(deleteCategoryUseCase.deleteCategory(anyLong())).willReturn(true);
+
+            // when, then
+            mockMvc.perform(delete(CATEGORY_ID_URL, ID))
+                .andDo(print())
+                .andExpect(status().isOk()) //TODO: 204로 수정 필요
+                .andDo(deleteCategoryDocumentation());
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #15

## 📌 PR 요약

카테고리(Category) JPA 엔티티 정의  
타 도메인 연관관계를 제외한 CRD 기능 구현  
관련 API 문서 작성

## 🔍 주요 변경 사항

- **카테고리 JPA 엔티티 추가**
  - `CategoryJpaEntity` 클래스 정의
    - `id`, `name` 필드 정의
    - `CATEGORY` 테이블에 매핑
    - JPA 기본 생성자와 빌더 패턴 제공
- **카테고리 저장소 생성**
  - `CategoryRepository` 생성
    - `JpaRepository` 상속
    - CRUD 처리 지원
- **카테고리 도메인 클래스 추가**
  - `Category` 클래스 정의
    - `id`, `name` 필드 포함
    - 데이터베이스 엔터티와 분리된 비즈니스 로직 중심 설계
- **카테고리 CRD 기능 구현**
  - **Create**: 카테고리 생성 API 및 저장 로직 구현
    - 요청 및 응답 데이터를 위한 DTO 클래스 추가
  - **Read**: 카테고리 조회 API 및 데이터 로드 어댑터 구현
    - 응답 데이터를 위한 DTO 클래스 추가
  - **Delete**: 카테고리 삭제 API 및 요청 처리 로직 구현
- **카테고리 테스트 추가**
  - CRD 기능별 API 테스트 작성
  - 테스트 데이터 생성을 위한 헬퍼 클래스 추가
  - 어댑터 동작 검증 테스트 작성
- **카테고리 API 문서화**
  - REST Docs를 활용하여 요청/응답 스펙 정의
  - 컨트롤러별 문서화 테스트 클래스 작성

## 🧪 테스트 방법
```
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- 기능 특성상 Update에 대한 기능을 필요시 추가 예정입니다.
- 응답 관련 수정 `TODO` 내용은 추후 요구사항에 적용할 예정입니다.
- 테스트 코드의 예외 및 BeanValidation 관련 필드 검증내용은 추후 추가 예정입니다.
- 타 도메인 연관관계는 추후 추가 예정입니다 